### PR TITLE
Update docs to remove DocuSign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository contains the Miliare Referral Network monorepo.  The design spec
 - `app_design/miliare-frontend` – Deprecated Next.js implementation.  Although not used directly, it includes useful components and features that should be replicated in the new codebase.  See the `design_docs/AGENTS.md` file in this folder for detailed Tailwind and lucide-react usage rules.
 - `apps/frontend-app` – The active Amplify Gen&nbsp;2 frontend using React + Vite.  All MVP features should be implemented here.
 - `infastructure/` – CDK stacks for functionality that Amplify Gen&nbsp;2 cannot support.  Over time the Amplify backend will migrate into `infastructure/miliare-infa-core`.
+- Preserve the Lucide icons exactly as used in `proto-mrn` to maintain the prototype look.
 
 ## Critical Icon Import Rule
 
@@ -31,7 +32,7 @@ Lines 12‑36 in `app_design/miliare-frontend/design_docs/AGENTS.md` explain why
 
 - Rebuild the prototype from `proto-mrn` inside `apps/frontend-app` while preserving the component structure found in `app_design/miliare-frontend`.
 - Migrate Amplify data models and backend logic into CDK stacks under `infastructure/miliare-infa-core`.
-- Implement DocuSign automation and bonus pool logic as CDK constructs (see `app_design/Nonfunctional_Features.md`).
+- DocuSign automation is no longer required; remove any remaining placeholder code and references.
 - Seed strategic partner data and replace temporary placeholder components with real models (see `app_design/Implementation_Plan.md`).
 - Continue to enforce specific icon imports to avoid memory issues.
 

--- a/app_design/Implementation_Plan.md
+++ b/app_design/Implementation_Plan.md
@@ -82,7 +82,6 @@
 - ✅ **WFG Integration**: SMD/EVC upline tracking
 
 #### **Document Management**
-- ✅ **DocuSign Placeholders**: Ready for 1099-NEC and direct deposit forms
 - ✅ **Document Tracking**: User profile document ID references
 
 ### 🔄 **Remaining Tasks (5% of Phase 1):**
@@ -103,7 +102,6 @@
 ### **Objectives:**
 - **Custom Infrastructure**: Mirror Amplify resources using CDK in `packages/backend`
 - **Performance Optimization**: Go Lambda resolvers for complex business logic
-- **Advanced Integration**: DocuSign API for automated document handling
 - **Business Logic Engine**: Automated commission calculations with audit trails
 - **Scalability**: Enterprise-grade infrastructure for production workloads
 
@@ -168,7 +166,6 @@ packages/backend/
 - **Partner Integration**: 7 strategic partners with flexible compensation
 - **Commission Precision**: Financial accuracy with cents-based storage
 - **Team Management**: Multi-level hierarchy with proper access control
-- **Document Workflow**: DocuSign integration points ready
 - **Compliance Ready**: 1099-NEC and tax reporting foundation
 
 ## 🚀 **Phase 1 Success Summary**

--- a/app_design/Nonfunctional_Features.md
+++ b/app_design/Nonfunctional_Features.md
@@ -2,12 +2,9 @@
 
 This document compiles the features described in the design specs and OpenAPI documentation that are not fully implemented in the current codebase. It also notes whether they should be tackled now with the Amplify Gen&nbsp;2 setup or deferred until the CDK backend migration.
 
-## 1. DocuSign Integration & Bonus Pools
+## 1. DocuSign Integration & Bonus Pools (Removed)
 
-- **OpenAPI definitions** include routes for creating envelopes, checking status and receiving callbacks from DocuSign along with several `/bonus-pools` endpoints.【F:app_design/openapi.yml†L246-L349】
-- **Current state**: the `ops` Lambda that should power these routes simply returns a "not implemented" message.【F:packages/backend/lambda/ops/main.go†L1-L27】
-
-**Recommendation**: Implement these endpoints after migrating to the CDK backend where the complex DocuSign automation and bonus-pool logic can be structured cleanly.
+This functionality is no longer part of the roadmap. The OpenAPI definitions and placeholder Lambdas remain for reference but will not be implemented. Any residual code can be safely deleted in future cleanups.
 
 ## 2. Partner Seeding & Dynamic Dashboards
 
@@ -16,12 +13,9 @@ This document compiles the features described in the design specs and OpenAPI do
 
 **Recommendation**: Temporary seeding in Amplify Gen&nbsp;2 is possible for demos, but the full dynamic solution should be implemented once the CDK backend is in place.
 
-## 3. Automated Document Workflow After Registration
+## 3. Automated Document Workflow After Registration (Removed)
 
-- The registration flow states that users will be redirected to DocuSign forms post‑signup, yet no code triggers these envelopes.
-- This feature depends on the unimplemented DocuSign APIs above.
-
-**Recommendation**: Defer implementation until the CDK backend phase alongside the DocuSign endpoints.
+The prototype originally called for redirecting users to DocuSign forms after sign up. Since DocuSign integration has been dropped, this workflow is no longer necessary and can be ignored.
 
 ## 4. Backend Infrastructure & Deployments
 
@@ -34,9 +28,9 @@ This document compiles the features described in the design specs and OpenAPI do
 
 | Feature | Amplify Gen&nbsp;2 Feasible? | Recommended Phase |
 | --- | --- | --- |
-| DocuSign integration & bonus pool APIs | ❌ Limited (placeholder only) | Implement with CDK backend |
+| DocuSign integration & bonus pool APIs | ❌ Removed from roadmap | N/A |
 | Partner seeding & dynamic dashboards | ⚠️ Possible now, but better with CDK | Begin after CDK migration (temporary demo seeding OK) |
-| Automated DocuSign workflow | ❌ Depends on unbuilt APIs | Implement with CDK backend |
+| Automated DocuSign workflow | ❌ Removed | N/A |
 | Infrastructure & deployments | ⚠️ Basic Amplify setup exists | Finalize with CDK migration |
 
 This list can guide planning for the upcoming phases and prioritize work during the backend transition.

--- a/app_design/miliare-frontend/design_docs/additional_pages.md
+++ b/app_design/miliare-frontend/design_docs/additional_pages.md
@@ -25,12 +25,8 @@ The current frontend includes login, registration, dashboard (business, learn, r
   - Table of payments with date, company, and amount
   - Filters by date range
 
-## DocuSign Completion Page
-- **Route:** `/register/complete`
-- **Purpose:** Confirmation page after registration where users are directed to complete DocuSign forms (1099‑NEC and direct deposit).
-- **Contents:**
-  - Instructions and links to DocuSign envelopes
-  - Option to return to dashboard when done
+## DocuSign Completion Page (Removed)
+- This page is no longer needed because DocuSign integration has been dropped.
 
 These pages enhance user experience and ensure that all requirements from the design specification are addressed.
 

--- a/app_design/miliare-frontend/design_docs/current_pages.md
+++ b/app_design/miliare-frontend/design_docs/current_pages.md
@@ -16,7 +16,7 @@ This document lists the pages that exist in the application as of this commit. I
 
 ## Registration Complete
 - **Route:** `/register/complete`
-- **Purpose:** Placeholder for DocuSign links (1099‑NEC and Direct Deposit) to finalize registration. Links back to the dashboard.
+- **Purpose:** This page was originally intended for DocuSign links but the integration has been removed. It can simply redirect to the dashboard.
 
 ## Dashboard (Layout)
 - **Route:** `/dashboard`

--- a/app_design/miliare-frontend/design_docs/openapi.yaml
+++ b/app_design/miliare-frontend/design_docs/openapi.yaml
@@ -6,6 +6,7 @@ info:
     Legacy REST API specification previously used for SSR data fetching.
     The project now relies on Amplify's GraphQL API and Storage for all data operations.
     Since the application is built with Amplify Gen 2, this file is retained for historical reference only.
+    DocuSign-related endpoints were removed from the current roadmap and remain here only for context.
 servers:
   - url: https://api.miliare.example.com
 paths:


### PR DESCRIPTION
## Summary
- update AGENTS instructions
- note removal of DocuSign features in design docs
- keep prototype icon usage

## Testing
- `pnpm frontend:test` *(fails: pnpm not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6848755790a8833282e85d3d41842602