### PR TITLE
Add referral form modal

### DIFF
--- a/apps/frontend-app/src/components/ReferralFormModal.tsx
+++ b/apps/frontend-app/src/components/ReferralFormModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Modal from './ui/Modal';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { toast } from './ui/Toaster';
+
+const formSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Valid email required'),
+  phone: z.string().min(1, 'Phone number is required'),
+  referralType: z.string().min(1, 'Type of referral is required'),
+  value: z.string().min(1, 'Approximate value is required'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface ReferralFormModalProps {
+  partnerName: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOpen, onClose }) => {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+  });
+
+  const close = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      await fetch('https://hooks.zapier.com/hooks/catch/16444537/uydvaog/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, source: partnerName }),
+      });
+      toast.success('Referral submitted', 'Thank you for your referral.');
+      close();
+    } catch (error) {
+      console.error('Referral submit error:', error);
+      toast.error('Submission failed', 'Please try again later.');
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={close} title={partnerName ? `Refer to ${partnerName}` : 'Refer Client'}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <Input label="Name" {...register('name')} error={errors.name?.message} />
+        <Input label="Email" type="email" {...register('email')} error={errors.email?.message} />
+        <Input label="Phone Number" type="tel" {...register('phone')} error={errors.phone?.message} />
+        <Input label="Type of Referral" {...register('referralType')} error={errors.referralType?.message} />
+        <Input label="Approximate Value" {...register('value')} error={errors.value?.message} />
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={close}>Cancel</Button>
+          <Button type="submit">Submit</Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default ReferralFormModal;

--- a/apps/frontend-app/src/components/ui/Modal.tsx
+++ b/apps/frontend-app/src/components/ui/Modal.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, className, children }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className={cn('relative z-10 w-full max-w-lg rounded-lg bg-white shadow-lg', className)}>
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
@@ -3,16 +3,18 @@ import {
   Send,
   CircleDollarSign,
   BadgePercent,
-  Link as LinkIcon 
+  Link as LinkIcon
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { partnersData } from '../../data/partnersData';
 import { toast } from '../../components/ui/Toaster';
+import ReferralFormModal from '../../components/ReferralFormModal';
 
 const ReferPage = () => {
   const [search, setSearch] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [activePartner, setActivePartner] = useState<string | null>(null);
   
   // Derive categories from partners data
   const categories = Array.from(
@@ -127,20 +129,14 @@ const ReferPage = () => {
                   Copy Link
                 </Button>
                 
-                <a 
-                  href={partner.referralUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="inline-block"
+                <Button
+                  className="w-full flex items-center justify-center"
+                  size="sm"
+                  onClick={() => setActivePartner(partner.name)}
                 >
-                  <Button
-                    className="w-full flex items-center justify-center"
-                    size="sm"
-                  >
-                    <Send className="mr-1 h-4 w-4" />
-                    Refer Now
-                  </Button>
-                </a>
+                  <Send className="mr-1 h-4 w-4" />
+                  Refer Now
+                </Button>
               </div>
             </div>
           </div>
@@ -195,6 +191,11 @@ const ReferPage = () => {
           </div>
         </div>
       </div>
+      <ReferralFormModal
+        partnerName={activePartner}
+        isOpen={Boolean(activePartner)}
+        onClose={() => setActivePartner(null)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create reusable `Modal` component
- implement `ReferralFormModal` to send info to Zapier
- update `ReferPage` to open modal and pass partner name

## Testing
- `pnpm frontend:test` *(fails: HTMLCanvasElement.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_b_6848c2eff0f08329ab641b826412517a