### PR TITLE
Fix Cognito attribute mapping on signup

### DIFF
--- a/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
+++ b/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
@@ -37,7 +37,9 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /^Admin$/i })
+    ).toBeInTheDocument();
   });
 
   it('hides Admin link for users without admin group', () => {

--- a/apps/frontend-app/src/components/EarningsChart.tsx
+++ b/apps/frontend-app/src/components/EarningsChart.tsx
@@ -7,6 +7,7 @@ import {
   LineElement,
   Tooltip,
   Legend,
+  type TooltipItem,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
@@ -79,8 +80,8 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
             font: {
               size: 12,
             },
-            callback: function(value: any) {
-              return '$' + value.toLocaleString();
+            callback: function(value: number | string) {
+              return '$' + Number(value).toLocaleString();
             },
           },
         },
@@ -96,7 +97,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
           borderColor: '#1e40af',
           borderWidth: 1,
           callbacks: {
-            label: function(context: any) {
+            label: function(context: TooltipItem<'line'>) {
               return 'Earnings: $' + context.parsed.y.toLocaleString();
             },
           },

--- a/apps/frontend-app/src/contexts/AuthContext.tsx
+++ b/apps/frontend-app/src/contexts/AuthContext.tsx
@@ -104,8 +104,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             email: userData.email,
             given_name: userData.firstName,
             family_name: userData.lastName,
-            // You can add custom attributes for company, upline, etc.
-            'custom:company': userData.company,
+            // Map the selected company to the PartnerId custom attribute in Cognito
+            'custom:partnerId': userData.company,
             'custom:uplineSMD': userData.uplineSMD || '',
             'custom:uplineEVC': userData.uplineEVC || '',
           },

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -1,10 +1,5 @@
 import React, { useState } from 'react';
-import {
-  TrendingUp,
-  Clock,
-  DollarSign,
-  Users,
-} from 'lucide-react';
+// Icons are referenced by name via an icon map; avoid importing unused icons
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
 import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';

--- a/apps/frontend-app/vitest.setup.ts
+++ b/apps/frontend-app/vitest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom';
+
+// Mock canvas context for Chart.js in testing environment
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: () => ({}),
+});


### PR DESCRIPTION
## Summary
- send company selection as `custom:partnerId`
- avoid unused lucide imports
- type chart callbacks and mock canvas in tests
- update admin link test to avoid ambiguous query

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_6848c47bd0f0833290ca08440a445218