### PR TITLE
Fix webhook submission errors

### DIFF
--- a/apps/frontend-app/.env.example
+++ b/apps/frontend-app/.env.example
@@ -1,1 +1,3 @@
-VITE_ZAPIER_WEBHOOK_URL=
+# Zapier Webhook URL used for referral form submissions
+# Replace with your actual hook URL in development/production
+VITE_ZAPIER_WEBHOOK_URL=https://hooks.zapier.com/hooks/catch/16444537/uydvaog/

--- a/apps/frontend-app/src/components/ReferralFormModal.tsx
+++ b/apps/frontend-app/src/components/ReferralFormModal.tsx
@@ -36,6 +36,11 @@ const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOp
   const onSubmit = async (data: FormValues) => {
     try {
       const webhookUrl = import.meta.env.VITE_ZAPIER_WEBHOOK_URL;
+      if (!webhookUrl) {
+        console.error('VITE_ZAPIER_WEBHOOK_URL not defined');
+        toast.error('Configuration error', 'Webhook URL missing.');
+        return;
+      }
       await fetch(webhookUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- improve ReferralFormModal error handling when webhook URL is missing
- provide example Zapier webhook URL in `.env.example`

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6848d10159c08329b943092a5985f36d