### PR TITLE
Add partner onboarding form

### DIFF
--- a/app_design/Implementation_Plan.md
+++ b/app_design/Implementation_Plan.md
@@ -196,3 +196,14 @@ aws-amplify
 ---
 
 **Status**: 🎉 **Miliare is ready for user onboarding and business validation!**
+
+## Partner Creation & Admin Invite Workflow
+
+Site administrators can onboard new partners directly from the dashboard. The workflow is:
+
+1. Navigate to **Company Admin → Create Partner** (visible only to `admin` users).
+2. Submit partner details along with the email for the partner's administrator.
+3. The frontend uses `generateClient<Schema>()` to create the Partner record.
+4. After creation, `invitePartnerAdmin` calls the Cognito Admin APIs to create the user, assign them to the `partnerAdmin` group and set the `custom:partnerId` attribute.
+5. The user receives an invite email from Cognito.
+6. Upon success the app redirects to a confirmation page showing the new partner ID and that the invite is pending.

--- a/apps/frontend-app/package.json
+++ b/apps/frontend-app/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.8.1",
+    "@aws-sdk/client-cognito-identity-provider": "^3.826.0",
     "@hookform/resolvers": "^3.3.4",
     "aws-amplify": "^6.8.1",
     "chart.js": "^4.4.2",

--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -7,6 +7,8 @@ import BusinessPage from './pages/dashboard/BusinessPage';
 import LearnPage from './pages/dashboard/LearnPage';
 import ReferPage from './pages/dashboard/ReferPage';
 import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
+import CreatePartnerPage from './pages/dashboard/CreatePartnerPage';
+import PartnerCreatedPage from './pages/dashboard/PartnerCreatedPage';
 import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
 import CompanyAdminPage from './pages/dashboard/CompanyAdminPage';
@@ -70,6 +72,16 @@ function App() {
           <Route path="company-admin" element={
             <ProtectedRoute requiredGroups={["partnerAdmin"]}>
               <CompanyAdminPage />
+            </ProtectedRoute>
+          } />
+          <Route path="company-admin/new-partner" element={
+            <ProtectedRoute requiredGroup="admin">
+              <CreatePartnerPage />
+            </ProtectedRoute>
+          } />
+          <Route path="company-admin/partner-created/:partnerId" element={
+            <ProtectedRoute requiredGroup="admin">
+              <PartnerCreatedPage />
             </ProtectedRoute>
           } />
           <Route path="admin" element={

--- a/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
+++ b/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
@@ -37,7 +37,7 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^admin$/i })).toBeInTheDocument();
   });
 
   it('hides Admin link for users without admin group', () => {

--- a/apps/frontend-app/src/__tests__/PartnerCreation.test.tsx
+++ b/apps/frontend-app/src/__tests__/PartnerCreation.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+import DashboardLayout from '../layouts/DashboardLayout';
+import * as AuthContext from '../contexts/AuthContext';
+import { invitePartnerAdmin } from '../utils/invitePartnerAdmin';
+
+// eslint-disable-next-line no-var
+var mockCreate: vi.Mock;
+vi.mock('aws-amplify/data', () => {
+  mockCreate = vi.fn();
+  return {
+    generateClient: vi.fn(() => ({
+      models: { Partner: { create: mockCreate } },
+    })),
+  };
+});
+vi.mock('../utils/invitePartnerAdmin', () => ({ invitePartnerAdmin: vi.fn() }));
+
+const baseAuth = {
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  logout: vi.fn(),
+  register: vi.fn(),
+};
+
+type UseAuthReturn = ReturnType<typeof AuthContext.useAuth>;
+
+vi.stubEnv('VITE_COGNITO_USER_POOL_ID', 'testpool');
+describe('Partner creation access', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('hides create partner link for partner admins', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: { id: '1', firstName: 'Partner', lastName: 'Admin', email: 'p@example.com', company: 'WFG', groups: ['partnerAdmin'] },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter>
+        <DashboardLayout />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/create partner/i)).not.toBeInTheDocument();
+  });
+
+  it('restricts new partner route to admins', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: { id: '2', firstName: 'User', lastName: 'A', email: 'u@example.com', company: 'WFG', groups: [] },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/company-admin/new-partner"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/create partner/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/your business dashboard/i)).toBeInTheDocument();
+  });
+
+  it('creates partner and invites admin', async () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: { id: '1', firstName: 'Admin', lastName: 'Root', email: 'admin@example.com', company: 'WFG', groups: ['admin'] },
+    } as UseAuthReturn);
+
+    mockCreate.mockResolvedValue({ id: '123' });
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/company-admin/new-partner"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(await screen.findByLabelText(/partner name/i), { target: { value: 'NewCo' } });
+    fireEvent.change(await screen.findByLabelText(/contact email/i), { target: { value: 'c@example.com' } });
+    fireEvent.change(await screen.findByLabelText(/website/i), { target: { value: 'https://new.co' } });
+    fireEvent.change(await screen.findByLabelText(/admin email/i), { target: { value: 'admin@new.co' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create partner/i }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(invitePartnerAdmin).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend-app/src/components/EarningsChart.tsx
+++ b/apps/frontend-app/src/components/EarningsChart.tsx
@@ -79,7 +79,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
             font: {
               size: 12,
             },
-            callback: function(value: any) {
+            callback: function(value: number) {
               return '$' + value.toLocaleString();
             },
           },
@@ -96,7 +96,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
           borderColor: '#1e40af',
           borderWidth: 1,
           callbacks: {
-            label: function(context: any) {
+            label: function(context: { parsed: { y: number } }) {
               return 'Earnings: $' + context.parsed.y.toLocaleString();
             },
           },

--- a/apps/frontend-app/src/components/ui/Input.tsx
+++ b/apps/frontend-app/src/components/ui/Input.tsx
@@ -7,15 +7,17 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, label, error, ...props }, ref) => {
+  ({ className, type, label, error, id, ...props }, ref) => {
+    const inputId = id || (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
     return (
       <div className="space-y-2">
         {label && (
-          <label className="block text-sm font-medium text-gray-700">
+          <label htmlFor={inputId} className="block text-sm font-medium text-gray-700">
             {label}
           </label>
         )}
         <input
+          id={inputId}
           type={type}
           className={cn(
             'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background',

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -1,10 +1,4 @@
 import React, { useState } from 'react';
-import {
-  TrendingUp,
-  Clock,
-  DollarSign,
-  Users,
-} from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
 import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';

--- a/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
 
 const CompanyAdminPage = () => {
+  const { user } = useAuth();
   return (
     <div className="space-y-8">
       <div>
@@ -11,12 +14,20 @@ const CompanyAdminPage = () => {
       </div>
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
         <p className="text-gray-700">
-          This page is accessible to Partner Admins and Site Admins. 
+          This page is accessible to Partner Admins and Site Admins.
           Manage company settings, partner configurations, and referral workflows here.
         </p>
+        {user?.groups?.includes('admin') && (
+          <div className="mt-4">
+            <Link to="/dashboard/company-admin/new-partner" className="text-primary underline">
+              Create Partner
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );
 };
 
-export default CompanyAdminPage; 
+export default CompanyAdminPage;
+

--- a/apps/frontend-app/src/pages/dashboard/CreatePartnerPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CreatePartnerPage.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '@/amplify/data/resource';
+import { Input } from '../../components/ui/Input';
+import { Button } from '../../components/ui/Button';
+import { useNavigate } from 'react-router-dom';
+import { invitePartnerAdmin } from '../../utils/invitePartnerAdmin';
+
+interface FormValues {
+  name: string;
+  contactEmail: string;
+  website: string;
+  description: string;
+  adminEmail: string;
+}
+
+const client = generateClient<Schema>();
+const userPoolId =
+  (import.meta.env as { VITE_COGNITO_USER_POOL_ID?: string }).VITE_COGNITO_USER_POOL_ID ||
+  process.env.VITE_COGNITO_USER_POOL_ID ||
+  '';
+
+const CreatePartnerPage = () => {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  const onSubmit = async (data: FormValues) => {
+    const partner = await client.models.Partner.create({
+      name: data.name,
+      contactEmail: data.contactEmail,
+      website: data.website,
+      description: data.description,
+    });
+
+    await invitePartnerAdmin(userPoolId, data.adminEmail, partner.id);
+
+    navigate(`/dashboard/company-admin/partner-created/${partner.id}`);
+  };
+
+  return (
+    <div className="space-y-6 max-w-xl">
+      <h1 className="text-2xl font-bold text-gray-900">Create Partner</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <Input label="Partner Name" {...register('name', { required: true })} error={errors.name && 'Required'} />
+        <Input label="Contact Email" type="email" {...register('contactEmail', { required: true })} error={errors.contactEmail && 'Required'} />
+        <Input label="Website" {...register('website', { required: true })} error={errors.website && 'Required'} />
+        <Input label="Description" {...register('description')} />
+        <Input label="Admin Email" type="email" {...register('adminEmail', { required: true })} error={errors.adminEmail && 'Required'} />
+        <Button type="submit">Create Partner</Button>
+      </form>
+    </div>
+  );
+};
+
+export default CreatePartnerPage;

--- a/apps/frontend-app/src/pages/dashboard/PartnerCreatedPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/PartnerCreatedPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+const PartnerCreatedPage = () => {
+  const { partnerId } = useParams();
+  return (
+    <div className="space-y-6 max-w-xl">
+      <h1 className="text-2xl font-bold text-gray-900">Partner Created</h1>
+      <p>The partner with ID {partnerId} was created and an admin invite was sent.</p>
+    </div>
+  );
+};
+
+export default PartnerCreatedPage;

--- a/apps/frontend-app/src/utils/invitePartnerAdmin.ts
+++ b/apps/frontend-app/src/utils/invitePartnerAdmin.ts
@@ -1,0 +1,29 @@
+import { CognitoIdentityProviderClient, AdminCreateUserCommand, AdminAddUserToGroupCommand, AdminUpdateUserAttributesCommand } from '@aws-sdk/client-cognito-identity-provider';
+
+export async function invitePartnerAdmin(userPoolId: string, email: string, partnerId: string) {
+  const client = new CognitoIdentityProviderClient({});
+
+  await client.send(new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: email,
+    UserAttributes: [
+      { Name: 'email', Value: email },
+      { Name: 'email_verified', Value: 'true' },
+    ],
+    DesiredDeliveryMediums: ['EMAIL'],
+  }));
+
+  await client.send(new AdminUpdateUserAttributesCommand({
+    UserPoolId: userPoolId,
+    Username: email,
+    UserAttributes: [{ Name: 'custom:partnerId', Value: partnerId }],
+  }));
+
+  await client.send(
+    new AdminAddUserToGroupCommand({
+      UserPoolId: userPoolId,
+      Username: email,
+      GroupName: 'partnerAdmin',
+    })
+  );
+}

--- a/apps/frontend-app/vitest.setup.ts
+++ b/apps/frontend-app/vitest.setup.ts
@@ -1,1 +1,23 @@
 import '@testing-library/jest-dom';
+vi.mock('chart.js', () => {
+  class FakeChart {
+    static register = vi.fn();
+  }
+  return {
+    Chart: FakeChart,
+    CategoryScale: {},
+    LinearScale: {},
+    PointElement: {},
+    LineElement: {},
+    Tooltip: {},
+    Legend: {},
+  };
+});
+vi.mock('react-chartjs-2', () => ({ Line: () => null }));
+vi.mock('aws-amplify/auth', () => ({
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+  getCurrentUser: vi.fn().mockRejectedValue({ name: 'UserUnAuthenticatedException' }),
+  fetchAuthSession: vi.fn().mockResolvedValue({ tokens: undefined }),
+}));

--- a/package.json
+++ b/package.json
@@ -9,17 +9,13 @@
     "frontend:start": "cd apps/frontend-app && pnpm run start",
     "frontend:lint": "cd apps/frontend-app && pnpm run lint",
     "frontend:test": "cd apps/frontend-app && pnpm run test",
-    
     "amplify:pull": "cd apps/frontend-app && amplify pull",
     "amplify:push": "cd apps/frontend-app && amplify push",
     "amplify:status": "cd apps/frontend-app && amplify status",
-    
     "install:all": "pnpm install",
-    
     "clean": "rm -rf node_modules apps/*/node_modules apps/frontend-app/dist",
     "format": "prettier --write \"apps/**/*.{ts,tsx,js,jsx,json,md}\""
   },
-
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=10.12.0"
@@ -38,7 +34,7 @@
     "typescript",
     "golang"
   ],
-
   "author": "richardstanley",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3.826.0
+        version: 3.826.0
     devDependencies:
       prettier:
         specifier: ^3.0.0
@@ -17,6 +21,9 @@ importers:
       '@aws-amplify/ui-react':
         specifier: ^6.8.1
         version: 6.11.2(@aws-amplify/core@6.12.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(aws-amplify@6.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(xstate@4.38.3)
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3.826.0
+        version: 3.826.0
       '@hookform/resolvers':
         specifier: ^3.3.4
         version: 3.10.0(react-hook-form@7.57.0(react@18.3.1))
@@ -802,6 +809,10 @@ packages:
 
   '@aws-sdk/client-codebuild@3.826.0':
     resolution: {integrity: sha512-qCCoB/vInZ+Q3OsMZl96FC+vzMJBTVWVJbqI0YrVmK6DA6KJiRgnQMzed8IGRLHfcW2M9cH+5ifc4K/nHG5Fbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-cognito-identity-provider@3.826.0':
+    resolution: {integrity: sha512-WaJw8uxm85IrNYqQUbV5NSO2M+iBDkknZe3MGXRjOaNg0YAzS8qUoApRO40x2G6da2RG0qRzIwS943ntA1sPrQ==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-cognito-identity@3.826.0':
@@ -8328,6 +8339,50 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cognito-identity-provider@3.826.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.826.0
+      '@aws-sdk/credential-provider-node': 3.826.0
+      '@aws-sdk/middleware-host-header': 3.821.0
+      '@aws-sdk/middleware-logger': 3.821.0
+      '@aws-sdk/middleware-recursion-detection': 3.821.0
+      '@aws-sdk/middleware-user-agent': 3.826.0
+      '@aws-sdk/region-config-resolver': 3.821.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@aws-sdk/util-user-agent-browser': 3.821.0
+      '@aws-sdk/util-user-agent-node': 3.826.0
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/core': 3.5.3
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.11
+      '@smithy/middleware-retry': 4.1.12
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.3
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.19
+      '@smithy/util-defaults-mode-node': 4.0.19
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-cognito-identity@3.826.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -11061,7 +11116,7 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/optimize@1.4.0(graphql@15.10.1)':
     dependencies:
@@ -11071,7 +11126,7 @@ snapshots:
   '@graphql-tools/optimize@2.0.0(graphql@15.10.1)':
     dependencies:
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@15.10.1)':
     dependencies:
@@ -11088,7 +11143,7 @@ snapshots:
       '@ardatan/relay-compiler': 12.0.3(graphql@15.10.1)
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
 
@@ -11097,7 +11152,7 @@ snapshots:
       '@graphql-tools/merge': 9.0.24(graphql@15.10.1)
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/schema@9.0.19(graphql@15.10.1)':
     dependencies:
@@ -11114,7 +11169,7 @@ snapshots:
       cross-inspect: 1.0.1
       dset: 3.1.4
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/utils@6.2.4(graphql@15.10.1)':
     dependencies:
@@ -12854,7 +12909,7 @@ snapshots:
 
   '@whatwg-node/promise-helpers@1.3.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@xstate/react@3.2.2(@types/react@18.3.23)(react@18.3.1)(xstate@4.38.3)':
     dependencies:
@@ -13531,7 +13586,7 @@ snapshots:
 
   cross-inspect@1.0.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -14336,7 +14391,7 @@ snapshots:
   graphql-tag@2.12.6(graphql@15.10.1):
     dependencies:
       graphql: 15.10.1
-      tslib: 2.3.1
+      tslib: 2.8.1
 
   graphql-transformer-common@4.34.0:
     dependencies:
@@ -14583,7 +14638,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -14652,7 +14707,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-weakmap@2.0.2: {}
 
@@ -16183,7 +16238,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -16326,7 +16381,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   symbol-tree@3.2.4: {}
 
@@ -16418,7 +16473,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   tmp@0.0.33:
     dependencies:


### PR DESCRIPTION
## Summary
- allow admins to create partners with a new form
- invite a partner admin via Cognito APIs
- restrict partner creation to admins
- document the partner creation workflow
- add tests for new access rules
- fix broken partner creation tests
- move Cognito SDK dependency to frontend package

## Testing
- `pnpm --filter ./apps/frontend-app lint`
- `pnpm --filter ./apps/frontend-app test`

------
https://chatgpt.com/codex/tasks/task_b_68490927e9408332bf6762c5c7fa06d2