### PR TITLE
Fix referral form CORS issue

### DIFF
--- a/apps/frontend-app/src/components/ReferralFormModal.tsx
+++ b/apps/frontend-app/src/components/ReferralFormModal.tsx
@@ -41,10 +41,14 @@ const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOp
         toast.error('Configuration error', 'Webhook URL missing.');
         return;
       }
+      const formData = new URLSearchParams();
+      Object.entries({ ...data, source: partnerName }).forEach(([key, value]) => {
+        formData.append(key, String(value));
+      });
       await fetch(webhookUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...data, source: partnerName }),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData.toString(),
       });
       toast.success('Referral submitted', 'Thank you for your referral.');
       close();


### PR DESCRIPTION
## Summary
- convert referral form submissions to `application/x-www-form-urlencoded`
  to avoid CORS preflight errors

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6849164243508329902926894d65f31a