### PR TITLE
Implement partner onboarding by admin

### DIFF
--- a/app_design/Implementation_Plan.md
+++ b/app_design/Implementation_Plan.md
@@ -196,3 +196,11 @@ aws-amplify
 ---
 
 **Status**: 🎉 **Miliare is ready for user onboarding and business validation!**
+
+## Admin Partner Onboarding
+
+The admin dashboard now includes a form for creating partner companies and inviting a designated partner administrator. When the form is submitted the app:
+1. Creates a `Partner` record via the Amplify Data client.
+2. Uses the AWS SDK `CognitoIdentityProviderClient` to create a new user, assign them to the `partnerAdmin` group and set the `custom:partnerId` attribute.
+
+Environment variables `VITE_AWS_REGION` and `VITE_COGNITO_USER_POOL_ID` must be configured for the invitation to succeed.

--- a/apps/frontend-app/package.json
+++ b/apps/frontend-app/package.json
@@ -29,7 +29,8 @@
     "react-hook-form": "^7.51.0",
     "react-router-dom": "^6.22.3",
     "tailwind-merge": "^2.6.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@aws-sdk/client-cognito-identity-provider": "^3.462.0"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.8.0",

--- a/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
+++ b/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
@@ -37,7 +37,7 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /site admin/i })).toBeInTheDocument();
   });
 
   it('hides Admin link for users without admin group', () => {
@@ -102,5 +102,26 @@ describe('Admin access', () => {
     );
 
     expect(screen.getByText(/admin dashboard/i)).toBeInTheDocument();
+  });
+
+  it('shows partner creation form on admin dashboard', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        company: 'WFG',
+        groups: ['admin'],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/admin"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /create new partner/i })).toBeInTheDocument();
   });
 });

--- a/apps/frontend-app/src/pages/dashboard/AdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/AdminPage.tsx
@@ -1,6 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+import { Input } from '../../components/ui/Input';
+import { Button } from '../../components/ui/Button';
+import { toast } from '../../components/ui/Toaster';
+import { invitePartnerAdmin } from '../../utils/invitePartnerAdmin';
+
+const client = generateClient<Schema>();
+
+const partnerSchema = z.object({
+  name: z.string().min(1, 'Partner name is required'),
+  contactEmail: z.string().email('Valid email required'),
+  website: z.string().url('Valid URL required'),
+  adminFirstName: z.string().min(1, 'First name required'),
+  adminLastName: z.string().min(1, 'Last name required'),
+  adminEmail: z.string().email('Valid email required'),
+});
+
+type PartnerFormValues = z.infer<typeof partnerSchema>;
 
 const AdminPage = () => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { register, handleSubmit, formState: { errors } } = useForm<PartnerFormValues>({
+    resolver: zodResolver(partnerSchema),
+  });
+
+  const onSubmit = async (data: PartnerFormValues) => {
+    setIsSubmitting(true);
+    try {
+      const { data: partner } = await client.models.Partner.create({
+        name: data.name,
+        contactEmail: data.contactEmail,
+        website: data.website,
+        status: 'ACTIVE',
+      });
+
+      await invitePartnerAdmin({
+        email: data.adminEmail,
+        firstName: data.adminFirstName,
+        lastName: data.adminLastName,
+        partnerId: partner.id,
+      });
+
+      toast.success('Partner created', 'Invitation sent to partner admin');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to create partner');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div className="space-y-8">
       <div>
@@ -10,7 +63,21 @@ const AdminPage = () => {
         </p>
       </div>
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-        <p className="text-gray-700">Only users in the admin group can see this page.</p>
+        <h2 className="text-xl font-semibold mb-4">Create New Partner</h2>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <Input label="Partner Name" {...register('name')} error={errors.name?.message} />
+          <Input label="Contact Email" {...register('contactEmail')} error={errors.contactEmail?.message} />
+          <Input label="Website" {...register('website')} error={errors.website?.message} />
+          <hr className="my-4" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Input label="Admin First Name" {...register('adminFirstName')} error={errors.adminFirstName?.message} />
+            <Input label="Admin Last Name" {...register('adminLastName')} error={errors.adminLastName?.message} />
+          </div>
+          <Input label="Admin Email" {...register('adminEmail')} error={errors.adminEmail?.message} />
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Creating...' : 'Create Partner'}
+          </Button>
+        </form>
       </div>
     </div>
   );

--- a/apps/frontend-app/src/utils/invitePartnerAdmin.ts
+++ b/apps/frontend-app/src/utils/invitePartnerAdmin.ts
@@ -1,0 +1,44 @@
+import { CognitoIdentityProviderClient, AdminCreateUserCommand, AdminAddUserToGroupCommand } from '@aws-sdk/client-cognito-identity-provider';
+
+export async function invitePartnerAdmin({
+  email,
+  firstName,
+  lastName,
+  partnerId,
+}: {
+  email: string;
+  firstName: string;
+  lastName: string;
+  partnerId: string;
+}) {
+  const region = import.meta.env.VITE_AWS_REGION;
+  const userPoolId = import.meta.env.VITE_COGNITO_USER_POOL_ID;
+
+  if (!region || !userPoolId) {
+    throw new Error('Missing Cognito configuration');
+  }
+
+  const client = new CognitoIdentityProviderClient({ region });
+
+  await client.send(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: email,
+      UserAttributes: [
+        { Name: 'email', Value: email },
+        { Name: 'email_verified', Value: 'true' },
+        { Name: 'given_name', Value: firstName },
+        { Name: 'family_name', Value: lastName },
+        { Name: 'custom:partnerId', Value: partnerId },
+      ],
+    })
+  );
+
+  await client.send(
+    new AdminAddUserToGroupCommand({
+      UserPoolId: userPoolId,
+      Username: email,
+      GroupName: 'partnerAdmin',
+    })
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-amplify/ui-react':
         specifier: ^6.8.1
         version: 6.11.2(@aws-amplify/core@6.12.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(aws-amplify@6.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(xstate@4.38.3)
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3.462.0
+        version: 3.826.0
       '@hookform/resolvers':
         specifier: ^3.3.4
         version: 3.10.0(react-hook-form@7.57.0(react@18.3.1))
@@ -802,6 +805,10 @@ packages:
 
   '@aws-sdk/client-codebuild@3.826.0':
     resolution: {integrity: sha512-qCCoB/vInZ+Q3OsMZl96FC+vzMJBTVWVJbqI0YrVmK6DA6KJiRgnQMzed8IGRLHfcW2M9cH+5ifc4K/nHG5Fbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-cognito-identity-provider@3.826.0':
+    resolution: {integrity: sha512-WaJw8uxm85IrNYqQUbV5NSO2M+iBDkknZe3MGXRjOaNg0YAzS8qUoApRO40x2G6da2RG0qRzIwS943ntA1sPrQ==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-cognito-identity@3.826.0':
@@ -8328,6 +8335,50 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cognito-identity-provider@3.826.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.826.0
+      '@aws-sdk/credential-provider-node': 3.826.0
+      '@aws-sdk/middleware-host-header': 3.821.0
+      '@aws-sdk/middleware-logger': 3.821.0
+      '@aws-sdk/middleware-recursion-detection': 3.821.0
+      '@aws-sdk/middleware-user-agent': 3.826.0
+      '@aws-sdk/region-config-resolver': 3.821.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@aws-sdk/util-user-agent-browser': 3.821.0
+      '@aws-sdk/util-user-agent-node': 3.826.0
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/core': 3.5.3
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.11
+      '@smithy/middleware-retry': 4.1.12
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.3
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.19
+      '@smithy/util-defaults-mode-node': 4.0.19
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-cognito-identity@3.826.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -11061,7 +11112,7 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/optimize@1.4.0(graphql@15.10.1)':
     dependencies:
@@ -11071,7 +11122,7 @@ snapshots:
   '@graphql-tools/optimize@2.0.0(graphql@15.10.1)':
     dependencies:
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@15.10.1)':
     dependencies:
@@ -11088,7 +11139,7 @@ snapshots:
       '@ardatan/relay-compiler': 12.0.3(graphql@15.10.1)
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
 
@@ -11097,7 +11148,7 @@ snapshots:
       '@graphql-tools/merge': 9.0.24(graphql@15.10.1)
       '@graphql-tools/utils': 10.8.6(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/schema@9.0.19(graphql@15.10.1)':
     dependencies:
@@ -11114,7 +11165,7 @@ snapshots:
       cross-inspect: 1.0.1
       dset: 3.1.4
       graphql: 15.10.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/utils@6.2.4(graphql@15.10.1)':
     dependencies:
@@ -12854,7 +12905,7 @@ snapshots:
 
   '@whatwg-node/promise-helpers@1.3.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@xstate/react@3.2.2(@types/react@18.3.23)(react@18.3.1)(xstate@4.38.3)':
     dependencies:
@@ -13531,7 +13582,7 @@ snapshots:
 
   cross-inspect@1.0.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -14336,7 +14387,7 @@ snapshots:
   graphql-tag@2.12.6(graphql@15.10.1):
     dependencies:
       graphql: 15.10.1
-      tslib: 2.3.1
+      tslib: 2.8.1
 
   graphql-transformer-common@4.34.0:
     dependencies:
@@ -14583,7 +14634,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -14652,7 +14703,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   is-weakmap@2.0.2: {}
 
@@ -16183,7 +16234,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -16326,7 +16377,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   symbol-tree@3.2.4: {}
 
@@ -16418,7 +16469,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   tmp@0.0.33:
     dependencies:


### PR DESCRIPTION
## Summary
- allow admins to create partner records and invite a partner admin
- expose invite helper using AWS Cognito admin APIs
- document new workflow in Implementation Plan
- extend admin access tests
- add Cognito SDK dependency

## Testing
- `pnpm --filter @miliare-referral-network/frontend-app test`

------
https://chatgpt.com/codex/tasks/task_b_68490372e7748332958c52136872f710