### PR TITLE
Enhance company admin dashboard

### DIFF
--- a/apps/frontend-app/amplify/backend.ts
+++ b/apps/frontend-app/amplify/backend.ts
@@ -3,7 +3,7 @@ import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { updateReferralStatusWebhook } from './functions/updateReferralStatusWebhook/resource';
 
-const backend = defineBackend({
+export const backend = defineBackend({
   auth,
   data,
   updateReferralStatusWebhook,

--- a/apps/frontend-app/src/components/RecentPaymentsCard.tsx
+++ b/apps/frontend-app/src/components/RecentPaymentsCard.tsx
@@ -8,16 +8,21 @@ export type RecentPayment = {
   amount: number;
   status: string;
   company: string;
+  paid?: boolean;
 };
 
 interface RecentPaymentsCardProps {
   payments: RecentPayment[];
   onViewHistory?: () => void;
+  showStatusToggle?: boolean;
+  onToggleStatus?: (id: number) => void;
 }
 
-const RecentPaymentsCard: React.FC<RecentPaymentsCardProps> = ({ 
-  payments, 
-  onViewHistory 
+const RecentPaymentsCard: React.FC<RecentPaymentsCardProps> = ({
+  payments,
+  onViewHistory,
+  showStatusToggle,
+  onToggleStatus,
 }) => {
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
@@ -30,7 +35,10 @@ const RecentPaymentsCard: React.FC<RecentPaymentsCardProps> = ({
       
       <div className="space-y-4">
         {payments.map((payment) => (
-          <div key={payment.id} className="flex items-center p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+          <div
+            key={payment.id}
+            className="flex items-center p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+          >
             <div className="flex-shrink-0">
               <CreditCard className="h-8 w-8 text-gray-400" />
             </div>
@@ -42,6 +50,17 @@ const RecentPaymentsCard: React.FC<RecentPaymentsCardProps> = ({
               <p className="text-sm font-semibold text-gray-900">${payment.amount.toLocaleString()}</p>
               <p className="text-xs font-medium text-green-600">{payment.status}</p>
             </div>
+            {showStatusToggle && (
+              <div className="ml-4">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onToggleStatus && onToggleStatus(payment.id)}
+                >
+                  {payment.paid ? 'Mark Unpaid' : 'Mark Paid'}
+                </Button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/apps/frontend-app/src/components/TeamMembersCard.tsx
+++ b/apps/frontend-app/src/components/TeamMembersCard.tsx
@@ -7,14 +7,22 @@ export type TeamMember = {
   totalReferrals: number;
   pendingCommissions: number;
   successRate: number; // value between 0 and 1
+  active?: boolean;
 };
 
 interface TeamMembersCardProps {
   members: TeamMember[];
   onViewAll?: () => void;
+  showStatusToggle?: boolean;
+  onToggleStatus?: (id: number) => void;
 }
 
-const TeamMembersCard: React.FC<TeamMembersCardProps> = ({ members, onViewAll }) => {
+const TeamMembersCard: React.FC<TeamMembersCardProps> = ({
+  members,
+  onViewAll,
+  showStatusToggle,
+  onToggleStatus,
+}) => {
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
       <div className="flex justify-between items-center mb-4">
@@ -36,6 +44,17 @@ const TeamMembersCard: React.FC<TeamMembersCardProps> = ({ members, onViewAll })
               <p>Pending Commissions: ${member.pendingCommissions.toLocaleString()}</p>
               <p>Success Rate: {Math.round(member.successRate * 100)}%</p>
             </div>
+            {showStatusToggle && (
+              <div className="mt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onToggleStatus && onToggleStatus(member.id)}
+                >
+                  {member.active ? 'Deactivate' : 'Activate'}
+                </Button>
+              </div>
+            )}
           </div>
         ))}
       </div>
@@ -57,6 +76,11 @@ const TeamMembersCard: React.FC<TeamMembersCardProps> = ({ members, onViewAll })
               <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Success Rate
               </th>
+              {showStatusToggle && (
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Action
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
@@ -74,6 +98,17 @@ const TeamMembersCard: React.FC<TeamMembersCardProps> = ({ members, onViewAll })
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                   {Math.round(member.successRate * 100)}%
                 </td>
+                {showStatusToggle && (
+                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onToggleStatus && onToggleStatus(member.id)}
+                    >
+                      {member.active ? 'Deactivate' : 'Activate'}
+                    </Button>
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { RefreshCw } from 'lucide-react';
-
-const iconMap = {
-  RefreshCw,
-};
 import { Button } from '../../components/ui/Button';
+import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';
+import StatsOverview, { StatItem } from '../../components/StatsOverview';
+import TeamMembersCard, { TeamMember } from '../../components/TeamMembersCard';
+import RecentPaymentsCard, { RecentPayment } from '../../components/RecentPaymentsCard';
+
+const iconMap = { RefreshCw };
 
 function generateApiKey() {
   const array = new Uint32Array(8);
@@ -14,25 +16,127 @@ function generateApiKey() {
 
 const CompanyAdminPage = () => {
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [period, setPeriod] = useState('Last 6 months');
+
+  const [members, setMembers] = useState<TeamMember[]>([
+    { id: 1, name: 'Alice Thompson', totalReferrals: 120, pendingCommissions: 3450.5, successRate: 0.76, active: true },
+    { id: 2, name: 'Brian Davis', totalReferrals: 98, pendingCommissions: 2150.0, successRate: 0.64, active: true },
+    { id: 3, name: 'Carla Martinez', totalReferrals: 150, pendingCommissions: 4800.75, successRate: 0.82, active: false },
+  ]);
+
+  const [payments, setPayments] = useState<RecentPayment[]>([
+    { id: 1, date: '2023-06-30', amount: 3200.5, status: 'Paid', company: 'Alice Thompson', paid: true },
+    { id: 2, date: '2023-06-25', amount: 2500.0, status: 'Paid', company: 'Brian Davis', paid: true },
+    { id: 3, date: '2023-06-20', amount: 4100.75, status: 'Unpaid', company: 'Carla Martinez', paid: false },
+  ]);
+
+  const earningsData6Months: EarningsPoint[] = [
+    { month: 'Jan', earnings: 15000 },
+    { month: 'Feb', earnings: 16500 },
+    { month: 'Mar', earnings: 17200 },
+    { month: 'Apr', earnings: 18400 },
+    { month: 'May', earnings: 19100 },
+    { month: 'Jun', earnings: 20500 },
+  ];
+
+  const earningsData12Months: EarningsPoint[] = [
+    { month: 'Jul', earnings: 14200 },
+    { month: 'Aug', earnings: 14800 },
+    { month: 'Sep', earnings: 15300 },
+    { month: 'Oct', earnings: 15800 },
+    { month: 'Nov', earnings: 16200 },
+    { month: 'Dec', earnings: 17000 },
+    ...earningsData6Months,
+  ].slice(-12);
+
+  const earningsDataYear: EarningsPoint[] = [...earningsData12Months];
+
+  const earningsMap: Record<string, EarningsPoint[]> = {
+    'Last 6 months': earningsData6Months,
+    'Last 12 months': earningsData12Months,
+    'Year to date': earningsDataYear,
+  };
+
+  const chartData = earningsMap[period] || earningsData6Months;
+
+  const stats: StatItem[] = [
+    { label: 'Total Earnings', value: '$112,500', icon: 'DollarSign', bgColor: 'bg-blue-100', iconColor: 'text-primary' },
+    { label: 'Pending Commissions', value: '$9,850', icon: 'Clock', bgColor: 'bg-green-100', iconColor: 'text-success' },
+    { label: 'Total Referrals', value: '368', icon: 'Users', bgColor: 'bg-purple-100', iconColor: 'text-purple-600' },
+    { label: 'Success Rate', value: '78%', icon: 'TrendingUp', bgColor: 'bg-orange-100', iconColor: 'text-orange-600' },
+  ];
+
   const RefreshIcon = iconMap.RefreshCw;
 
   const handleRegenerate = () => {
     const key = generateApiKey();
     setApiKey(key);
-    // TODO: call backend mutation to store hashed key
   };
+
+  const toggleMemberStatus = (id: number) => {
+    setMembers((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, active: !m.active } : m))
+    );
+  };
+
+  const togglePaymentStatus = (id: number) => {
+    setPayments((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, paid: !p.paid, status: p.paid ? 'Unpaid' : 'Paid' } : p
+      )
+    );
+  };
+
+  const handleViewHistory = () => {
+    console.log('View payment history');
+  };
+
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Company Admin Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Manage partner companies and referral settings.
-        </p>
+        <p className="mt-1 text-sm text-gray-500">Manage partner companies and referral settings.</p>
       </div>
+
+      <StatsOverview stats={stats} />
+
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">Partner Earnings Overview</h2>
+          <div>
+            <select
+              className="py-1 px-3 border border-gray-300 rounded-md text-sm"
+              value={period}
+              onChange={(e) => setPeriod(e.target.value)}
+            >
+              <option>Last 6 months</option>
+              <option>Last 12 months</option>
+              <option>Year to date</option>
+            </select>
+          </div>
+        </div>
+        <div className="h-64">
+          <EarningsChart data={chartData} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <TeamMembersCard
+          members={members}
+          showStatusToggle
+          onToggleStatus={toggleMemberStatus}
+        />
+        <RecentPaymentsCard
+          payments={payments}
+          onViewHistory={handleViewHistory}
+          showStatusToggle
+          onToggleStatus={togglePaymentStatus}
+        />
+      </div>
+
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100 space-y-4">
         <p className="text-gray-700">
-          This page is accessible to Partner Admins and Site Admins.
-          Manage company settings, partner configurations, and referral workflows here.
+          This page is accessible to Partner Admins and Site Admins. Manage company settings, partner configurations, and referral workflows here.
         </p>
         <div>
           <p className="text-sm text-gray-500">Webhook Endpoint:</p>


### PR DESCRIPTION
## Summary
- update TeamMembersCard and RecentPaymentsCard to support status toggles
- adjust backend export to satisfy lint
- rebuild CompanyAdminPage with charts, stats, member/payment toggles, and API key card

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6849d63b0a4c8332896435dbcad9adc6