### PR TITLE
Fix lint issues post API key update

### DIFF
--- a/apps/frontend-app/amplify/backend.ts
+++ b/apps/frontend-app/amplify/backend.ts
@@ -6,7 +6,7 @@ import {
   LambdaIntegration,
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { updateReferralStatusWebhook } from './functions/updateReferralStatusWebhook/resource';

--- a/apps/frontend-app/src/components/EarningsChart.tsx
+++ b/apps/frontend-app/src/components/EarningsChart.tsx
@@ -7,6 +7,7 @@ import {
   LineElement,
   Tooltip,
   Legend,
+  type TooltipItem,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
@@ -79,7 +80,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
             font: {
               size: 12,
             },
-            callback: function(value: any) {
+            callback(value: number | string) {
               return '$' + value.toLocaleString();
             },
           },
@@ -96,7 +97,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
           borderColor: '#1e40af',
           borderWidth: 1,
           callbacks: {
-            label: function(context: any) {
+            label(context: TooltipItem<'line'>) {
               return 'Earnings: $' + context.parsed.y.toLocaleString();
             },
           },

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -1,10 +1,4 @@
 import React, { useState } from 'react';
-import {
-  TrendingUp,
-  Clock,
-  DollarSign,
-  Users,
-} from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
 import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';


### PR DESCRIPTION
## Summary
- remove unused IAM import in API backend
- clean up unused Lucide icon imports
- type chart callback parameters in EarningsChart

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6849a272ac048332bd3620ca52d3c7ee