### PR TITLE
Add partner overview stats

### DIFF
--- a/apps/frontend-app/src/data/partnerAggregateStats.ts
+++ b/apps/frontend-app/src/data/partnerAggregateStats.ts
@@ -1,0 +1,51 @@
+export type PartnerAggregateStats = {
+  totalEarnings: number;
+  pendingCommissions: number;
+  referralsCount: number;
+  successfulReferrals: number;
+};
+
+export const partnerAggregateStats: Record<string, PartnerAggregateStats> = {
+  'sunny-hill': {
+    totalEarnings: 125000,
+    pendingCommissions: 6200,
+    referralsCount: 340,
+    successfulReferrals: 280,
+  },
+  prime: {
+    totalEarnings: 98000,
+    pendingCommissions: 5400,
+    referralsCount: 290,
+    successfulReferrals: 210,
+  },
+  anco: {
+    totalEarnings: 76000,
+    pendingCommissions: 4300,
+    referralsCount: 220,
+    successfulReferrals: 170,
+  },
+  weightless: {
+    totalEarnings: 54000,
+    pendingCommissions: 2100,
+    referralsCount: 180,
+    successfulReferrals: 130,
+  },
+  summit: {
+    totalEarnings: 88000,
+    pendingCommissions: 5100,
+    referralsCount: 250,
+    successfulReferrals: 190,
+  },
+  wellness: {
+    totalEarnings: 67000,
+    pendingCommissions: 3200,
+    referralsCount: 200,
+    successfulReferrals: 150,
+  },
+  impact: {
+    totalEarnings: 72000,
+    pendingCommissions: 3500,
+    referralsCount: 210,
+    successfulReferrals: 160,
+  },
+};

--- a/apps/frontend-app/src/pages/dashboard/PartnerDetailPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/PartnerDetailPage.tsx
@@ -9,11 +9,13 @@ import {
   CircleDollarSign, 
   BadgePercent, 
   CreditCard,
-  Link2 
+  Link2
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { partnersData } from '../../data/partnersData';
 import { toast } from '../../components/ui/Toaster';
+import StatsOverview, { StatItem } from '../../components/StatsOverview';
+import { partnerAggregateStats } from '../../data/partnerAggregateStats';
 
 const PartnerDetailPage = () => {
   const { partnerId } = useParams<{ partnerId: string }>();
@@ -22,8 +24,45 @@ const PartnerDetailPage = () => {
   const partner = useMemo(() => {
     return partnersData.find(p => p.id === partnerId);
   }, [partnerId]);
-  
-  // If partner not found, redirect to Learn page
+
+  const aggregate = partnerAggregateStats[partnerId || ''];
+
+  const stats: StatItem[] = useMemo(() => {
+    if (!aggregate) return [];
+    return [
+      {
+        label: 'Total Earnings',
+        value: `$${aggregate.totalEarnings.toLocaleString()}`,
+        icon: 'DollarSign',
+        bgColor: 'bg-blue-100',
+        iconColor: 'text-primary',
+      },
+      {
+        label: 'Pending Commissions',
+        value: `$${aggregate.pendingCommissions.toLocaleString()}`,
+        icon: 'Clock',
+        bgColor: 'bg-green-100',
+        iconColor: 'text-success',
+      },
+      {
+        label: 'Total Referrals',
+        value: aggregate.referralsCount.toString(),
+        icon: 'Users',
+        bgColor: 'bg-purple-100',
+        iconColor: 'text-purple-600',
+      },
+      {
+        label: 'Success Rate',
+        value: `${Math.round(
+          (aggregate.successfulReferrals / aggregate.referralsCount) * 100
+        )}%`,
+        icon: 'TrendingUp',
+        bgColor: 'bg-orange-100',
+        iconColor: 'text-orange-600',
+      },
+    ];
+  }, [aggregate]);
+
   if (!partner) {
     navigate('/dashboard/learn');
     return null;
@@ -102,7 +141,9 @@ const PartnerDetailPage = () => {
           </p>
         </div>
       </div>
-      
+
+      {stats.length > 0 && <StatsOverview stats={stats} />}
+
       {/* Partner overview */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
         <div className="md:flex">


### PR DESCRIPTION
## Summary
- show aggregated score card on Partner Detail Page
- provide sample partner aggregates for demo

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6849da11769c8332b6e724339ec5a07e