### PR TITLE
Enable profile updates from dashboard

### DIFF
--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -10,6 +10,7 @@ import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
 import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
 import CompanyAdminPage from './pages/dashboard/CompanyAdminPage';
+import ProfilePage from './pages/dashboard/ProfilePage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
 import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import { Toaster } from './components/ui/Toaster';
@@ -62,6 +63,7 @@ function App() {
           <Route index element={<BusinessPage />} />
           <Route path="learn" element={<LearnPage />} />
           <Route path="refer" element={<ReferPage />} />
+          <Route path="profile" element={<ProfilePage />} />
           <Route path="team" element={
             <ProtectedRoute requiredGroup="teamLead">
               <TeamPage />

--- a/apps/frontend-app/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend-app/src/layouts/DashboardLayout.tsx
@@ -120,7 +120,7 @@ const DashboardLayout = () => {
                       className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                       onClick={() => {
                         setIsProfileMenuOpen(false);
-                        // Navigate to profile page when implemented
+                        navigate('/dashboard/profile');
                       }}
                     >
                       <User className="inline-block mr-2 h-4 w-4" />
@@ -206,7 +206,7 @@ const DashboardLayout = () => {
                   className="block w-full text-left px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100"
                   onClick={() => {
                     closeMobileMenu();
-                    // Navigate to profile page when implemented
+                    navigate('/dashboard/profile');
                   }}
                 >
                   Your Profile

--- a/apps/frontend-app/src/pages/dashboard/ProfilePage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/ProfilePage.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from '../../components/ui/Input';
+import { Select } from '../../components/ui/Select';
+import { Button } from '../../components/ui/Button';
+import { useAuth } from '../../contexts/AuthContext';
+import { toast } from '../../components/ui/Toaster';
+
+const companies = [
+  { value: 'WFG', label: 'WFG' },
+  { value: 'Sunny Hill Financial', label: 'Sunny Hill Financial' },
+  { value: 'Prime Corporate Services', label: 'Prime Corporate Services' },
+  { value: 'ANCO', label: 'ANCO' },
+  { value: 'Weightless Financial', label: 'Weightless Financial' },
+  { value: 'Summit Business Syndicate', label: 'Summit Business Syndicate' },
+  { value: 'Wellness for the Workforce', label: 'Wellness for the Workforce' },
+  { value: 'Impact Health Sharing', label: 'Impact Health Sharing' },
+  { value: 'Other', label: 'Other' },
+];
+
+const profileSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  company: z.string().min(1, 'Please select your company'),
+  uplineEVC: z.string().optional(),
+  uplineSMD: z.string().optional(),
+});
+
+type ProfileFormValues = z.infer<typeof profileSchema>;
+
+const ProfilePage: React.FC = () => {
+  const { user, updateProfile } = useAuth();
+
+  const { register, handleSubmit, formState: { errors } } = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      firstName: user?.firstName || '',
+      lastName: user?.lastName || '',
+      company: user?.company || '',
+      uplineEVC: user?.uplineEVC || '',
+      uplineSMD: user?.uplineSMD || '',
+    },
+  });
+
+  const onSubmit = async (data: ProfileFormValues) => {
+    try {
+      await updateProfile(data);
+      toast.success('Profile updated', 'Your changes have been saved.');
+    } catch (error) {
+      console.error('Profile update error:', error);
+      toast.error('Update failed', 'Unable to update profile.');
+    }
+  };
+
+  return (
+    <div className="bg-white shadow sm:rounded-lg p-6">
+      <h1 className="text-2xl font-semibold mb-4">Your Profile</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Input label="First Name" {...register('firstName')} error={errors.firstName?.message} />
+          <Input label="Last Name" {...register('lastName')} error={errors.lastName?.message} />
+        </div>
+        <Select label="Company" options={companies} {...register('company')} error={errors.company?.message} />
+        <Input label="Upline EVC" {...register('uplineEVC')} error={errors.uplineEVC?.message} />
+        <Input label="Upline SMD" {...register('uplineSMD')} error={errors.uplineSMD?.message} />
+        <div className="pt-4">
+          <Button type="submit">Update Profile</Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ProfilePage;


### PR DESCRIPTION
## Summary
- add updateProfile helper to AuthContext
- create profile editing page
- navigate to profile editing page from dropdown
- register the profile page in router

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684a40b56efc8332aba103d6e3339295