### PR TITLE
Add settings page for password changes

### DIFF
--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -11,6 +11,7 @@ import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
 import CompanyAdminPage from './pages/dashboard/CompanyAdminPage';
 import ProfilePage from './pages/dashboard/ProfilePage';
+import SettingsPage from './pages/dashboard/SettingsPage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
 import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import { Toaster } from './components/ui/Toaster';
@@ -64,6 +65,7 @@ function App() {
           <Route path="learn" element={<LearnPage />} />
           <Route path="refer" element={<ReferPage />} />
           <Route path="profile" element={<ProfilePage />} />
+          <Route path="settings" element={<SettingsPage />} />
           <Route path="team" element={
             <ProtectedRoute requiredGroup="teamLead">
               <TeamPage />

--- a/apps/frontend-app/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend-app/src/layouts/DashboardLayout.tsx
@@ -130,7 +130,7 @@ const DashboardLayout = () => {
                       className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                       onClick={() => {
                         setIsProfileMenuOpen(false);
-                        // Navigate to settings page when implemented
+                        navigate('/dashboard/settings');
                       }}
                     >
                       <Settings className="inline-block mr-2 h-4 w-4" />
@@ -215,7 +215,7 @@ const DashboardLayout = () => {
                   className="block w-full text-left px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100"
                   onClick={() => {
                     closeMobileMenu();
-                    // Navigate to settings page when implemented
+                    navigate('/dashboard/settings');
                   }}
                 >
                   Settings

--- a/apps/frontend-app/src/pages/dashboard/SettingsPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/SettingsPage.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from '../../components/ui/Input';
+import { Button } from '../../components/ui/Button';
+import { toast } from '../../components/ui/Toaster';
+import { updatePassword } from 'aws-amplify/auth';
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: z
+      .string()
+      .min(8, 'Password must be at least 8 characters')
+      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+      .regex(/[0-9]/, 'Password must contain at least one number')
+      .regex(/[^a-zA-Z0-9]/, 'Password must contain at least one symbol (!@#$%^&*)'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+type PasswordFormValues = z.infer<typeof passwordSchema>;
+
+const SettingsPage: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<PasswordFormValues>({ resolver: zodResolver(passwordSchema) });
+
+  const onSubmit = async (values: PasswordFormValues) => {
+    try {
+      await updatePassword({
+        oldPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      });
+      toast.success('Password updated', 'Your password has been changed.');
+      reset();
+    } catch (error) {
+      console.error('Password change error:', error);
+      toast.error('Update failed', 'Unable to change password.');
+    }
+  };
+
+  return (
+    <div className="bg-white shadow sm:rounded-lg p-6">
+      <h1 className="text-2xl font-semibold mb-4">Account Settings</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md">
+        <Input
+          label="Current Password"
+          type="password"
+          autoComplete="current-password"
+          {...register('currentPassword')}
+          error={errors.currentPassword?.message}
+        />
+        <Input
+          label="New Password"
+          type="password"
+          autoComplete="new-password"
+          {...register('newPassword')}
+          error={errors.newPassword?.message}
+        />
+        <Input
+          label="Confirm New Password"
+          type="password"
+          autoComplete="new-password"
+          {...register('confirmPassword')}
+          error={errors.confirmPassword?.message}
+        />
+        <div className="pt-4">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Updating...' : 'Update Password'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- implement password change page
- enable Settings links in profile dropdown and mobile menu
- route `/dashboard/settings`

## Testing
- `pnpm run frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684a4894512c8332b78bf26aaa157414