### PR TITLE
Fix dropdown sign-out action

### DIFF
--- a/apps/frontend-app/src/contexts/AuthContext.tsx
+++ b/apps/frontend-app/src/contexts/AuthContext.tsx
@@ -18,7 +18,7 @@ type AuthContextType = {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (email: string, password: string, rememberMe?: boolean) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   register: (
     userData: Omit<User, 'id' | 'groups'> & { password: string }
   ) => Promise<boolean>;

--- a/apps/frontend-app/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend-app/src/layouts/DashboardLayout.tsx
@@ -23,8 +23,8 @@ const DashboardLayout = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     toast.info('Logged out successfully');
     navigate('/login');
   };


### PR DESCRIPTION
## Summary
- fix `logout` type in AuthContext
- await logout when signing out from the dropdown

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_b_684a524955588332b63a3107052ebf3b