### PR TITLE
Add referral status update REST API

### DIFF
--- a/apps/frontend-app/amplify/backend.ts
+++ b/apps/frontend-app/amplify/backend.ts
@@ -1,4 +1,12 @@
 import { defineBackend } from '@aws-amplify/backend';
+import { Stack } from 'aws-cdk-lib';
+import {
+  AuthorizationType,
+  Cors,
+  LambdaIntegration,
+  RestApi,
+} from 'aws-cdk-lib/aws-apigateway';
+import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { updateReferralStatusWebhook } from './functions/updateReferralStatusWebhook/resource';
@@ -9,5 +17,60 @@ export const backend = defineBackend({
   updateReferralStatusWebhook,
 });
 
-// TODO: Re-add REST API configuration once frontend issue is resolved
-// The function is still deployed and accessible via direct Lambda invocation
+// Create a new API stack for the webhook REST API
+const apiStack = backend.createStack('webhook-api-stack');
+
+// Define the REST API using API Gateway
+const webhookRestApi = new RestApi(apiStack, 'WebhookRestApi', {
+  restApiName: 'referralWebhookApi',
+  deploy: true,
+  deployOptions: {
+    stageName: 'prod',
+  },
+  defaultCorsPreflightOptions: {
+    allowOrigins: Cors.ALL_ORIGINS,
+    allowMethods: ['POST', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'x-api-key', 'Authorization'],
+  },
+});
+
+// API key validation handled by the Lambda
+const webhookLambdaIntegration = new LambdaIntegration(
+  backend.updateReferralStatusWebhook.resources.lambda
+);
+
+// Create the /webhook/referrals/{referralId} path
+const webhookPath = webhookRestApi.root.addResource('webhook');
+const referralsPath = webhookPath.addResource('referrals');
+const referralIdPath = referralsPath.addResource('{referralId}', {
+  defaultMethodOptions: {
+    authorizationType: AuthorizationType.NONE,
+  },
+});
+
+referralIdPath.addMethod('POST', webhookLambdaIntegration);
+
+// Grant the function access to query Partner and Referral models
+backend.updateReferralStatusWebhook.resources.lambda.addToRolePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ['appsync:GraphQL'],
+    resources: [
+      `${backend.data.resources.graphqlApi.arn}/types/Partner/fields/*`,
+      `${backend.data.resources.graphqlApi.arn}/types/Referral/fields/*`,
+    ],
+  })
+);
+
+// Output the API endpoint details for reference
+backend.addOutput({
+  custom: {
+    API: {
+      [webhookRestApi.restApiName]: {
+        endpoint: webhookRestApi.url,
+        region: Stack.of(webhookRestApi).region,
+        apiName: webhookRestApi.restApiName,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- expose `updateReferralStatusWebhook` through API Gateway
- wire up REST endpoint `/webhook/referrals/{referralId}`
- grant lambda permissions to query data models
- output API details for partners

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_b_684a63d277948332b635d368273ae68a