### PR TITLE
Rename CompanyAdmin page to OrganizationPage

### DIFF
--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -9,7 +9,7 @@ import ReferPage from './pages/dashboard/ReferPage';
 import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
 import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
-import CompanyAdminPage from './pages/dashboard/CompanyAdminPage';
+import OrganizationPage from './pages/dashboard/OrganizationPage';
 import ProfilePage from './pages/dashboard/ProfilePage';
 import SettingsPage from './pages/dashboard/SettingsPage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
@@ -73,7 +73,7 @@ function App() {
           } />
           <Route path="company-admin" element={
             <ProtectedRoute requiredGroups={["partnerAdmin"]}>
-              <CompanyAdminPage />
+              <OrganizationPage />
             </ProtectedRoute>
           } />
           <Route path="admin" element={

--- a/apps/frontend-app/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend-app/src/layouts/DashboardLayout.tsx
@@ -52,7 +52,7 @@ const DashboardLayout = () => {
   }
 
   if (user?.groups?.includes('partnerAdmin') || user?.groups?.includes('admin')) {
-    navLinks.push({ to: '/dashboard/company-admin', icon: <Settings className="h-5 w-5" />, label: 'Admin' });
+    navLinks.push({ to: '/dashboard/company-admin', icon: <Settings className="h-5 w-5" />, label: 'Organization' });
   }
 
   if (user?.groups?.includes('admin')) {

--- a/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
@@ -14,7 +14,7 @@ function generateApiKey() {
   return Array.from(array, (val) => val.toString(16).padStart(8, '0')).join('');
 }
 
-const CompanyAdminPage = () => {
+const OrganizationPage = () => {
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [period, setPeriod] = useState('Last 6 months');
 
@@ -94,7 +94,7 @@ const CompanyAdminPage = () => {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Company Admin Dashboard</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Organization Dashboard</h1>
         <p className="mt-1 text-sm text-gray-500">Manage partner companies and referral settings.</p>
       </div>
 
@@ -154,4 +154,4 @@ const CompanyAdminPage = () => {
   );
 };
 
-export default CompanyAdminPage;
+export default OrganizationPage;


### PR DESCRIPTION
## Summary
- rename `CompanyAdminPage` to `OrganizationPage`
- update route usage in `App.tsx`
- relabel dashboard navigation link to **Organization**

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684ae16b39948332a291e73065ff0bbe