### PR TITLE
Rename partner terminology to company

### DIFF
--- a/apps/frontend-app/amplify/auth/resource.ts
+++ b/apps/frontend-app/amplify/auth/resource.ts
@@ -37,7 +37,7 @@ export const auth = defineAuth({
       mutable: true,
     },
     // Custom attributes for Miliare business domain
-    'custom:partnerId': {
+    'custom:companyId': {
       dataType: 'String',
       mutable: true,
     },

--- a/apps/frontend-app/amplify/backend.ts
+++ b/apps/frontend-app/amplify/backend.ts
@@ -50,13 +50,13 @@ const referralIdPath = referralsPath.addResource('{referralId}', {
 
 referralIdPath.addMethod('POST', webhookLambdaIntegration);
 
-// Grant the function access to query Partner and Referral models
+// Grant the function access to query Company and Referral models
 backend.updateReferralStatusWebhook.resources.lambda.addToRolePolicy(
   new PolicyStatement({
     effect: Effect.ALLOW,
     actions: ['appsync:GraphQL'],
     resources: [
-      `${backend.data.resources.graphqlApi.arn}/types/Partner/fields/*`,
+      `${backend.data.resources.graphqlApi.arn}/types/Company/fields/*`,
       `${backend.data.resources.graphqlApi.arn}/types/Referral/fields/*`,
     ],
   })

--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -35,8 +35,8 @@ const schema = a.schema({
       index("teamId").sortKeys(["id"]).queryField("listUsersByTeam"),
     ]),
 
-  // Strategic Partners model
-  Partner: a
+  // Strategic Companies model
+  Company: a
     .model({
       id: a.id(),
       name: a.string().required(),
@@ -54,21 +54,21 @@ const schema = a.schema({
       trainingLinks: a.string().array(),
       webhookApiKeyHash: a.string(),
       webhookUrl: a.string(),
-      referrals: a.hasMany("Referral", "partnerId"),
+      referrals: a.hasMany("Referral", "companyId"),
     })
     .authorization((allow) => [
       allow.authenticated().to(["read"]),
       allow.groups(["admin"]),
-      allow.groups(["partnerAdmin"]).to(["read", "update"]),
+      allow.groups(["companyAdmin"]).to(["read", "update"]),
       allow.groups(["teamLead"]).to(["read"])
     ]),
 
-  // Referrals model - tracks leads sent to partners
+  // Referrals model - tracks leads sent to companies
   Referral: a
     .model({
       id: a.id(),
       userProfileId: a.id().required(), // References UserProfile
-      partnerId: a.id().required(), // References Partner
+      companyId: a.id().required(), // References Company
       leadId: a.string().required(),
       clientName: a.string().required(),
       status: a.enum(["IN_PROGRESS", "IN_REVIEW", "PAID", "REJECTED"]),
@@ -82,12 +82,12 @@ const schema = a.schema({
       bonusPoolAmount: a.integer(),
       mrnAmount: a.integer(),
       contractorAmount: a.integer(),
-      partnerType: a.enum(["DIRECT_PAYMENT", "MRN_PAYMENT"]),
+      companyType: a.enum(["DIRECT_PAYMENT", "MRN_PAYMENT"]),
       paymentStatus: a.enum(["PENDING", "PROCESSED", "FAILED"]),
       notes: a.string(),
       paidAt: a.datetime(),
       userProfile: a.belongsTo("UserProfile", "userProfileId"),
-      partner: a.belongsTo("Partner", "partnerId"),
+      company: a.belongsTo("Company", "companyId"),
       payments: a.hasMany("Payment", "referralId"),
     })
     .authorization((allow) => [

--- a/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
+++ b/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
@@ -40,25 +40,25 @@ export const handler = async (event: APIGatewayEvent): Promise<APIGatewayRespons
   });
 
   try {
-    // Find partner by apiKey hash
-    const partners = await client.models.Partner.list({
-      filter: { webhookApiKeyHash: { eq: hash } },
-    });
+  // Find company by apiKey hash
+  const companies = await client.models.Company.list({
+    filter: { webhookApiKeyHash: { eq: hash } },
+  });
 
-    const partner = partners.data[0];
-    if (!partner) {
-      return { statusCode: 403, body: 'Invalid API key' };
-    }
+  const company = companies.data[0];
+  if (!company) {
+    return { statusCode: 403, body: 'Invalid API key' };
+  }
 
     const referralId = event.pathParameters?.referralId;
     if (!referralId) {
       return { statusCode: 400, body: 'Missing referral ID' };
     }
 
-    const referral = await client.models.Referral.get({ id: referralId });
-    if (!referral.data || referral.data.partnerId !== partner.id) {
-      return { statusCode: 404, body: 'Referral not found' };
-    }
+  const referral = await client.models.Referral.get({ id: referralId });
+  if (!referral.data || referral.data.companyId !== company.id) {
+    return { statusCode: 404, body: 'Referral not found' };
+  }
 
     const body = JSON.parse(event.body || '{}');
     const status = body.status as Schema['Referral']['type']['status'];

--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -6,7 +6,7 @@ import DashboardLayout from './layouts/DashboardLayout';
 import BusinessPage from './pages/dashboard/BusinessPage';
 import LearnPage from './pages/dashboard/LearnPage';
 import ReferPage from './pages/dashboard/ReferPage';
-import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
+import CompanyDetailPage from './pages/dashboard/CompanyDetailPage';
 import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
 import OrganizationPage from './pages/dashboard/OrganizationPage';
@@ -74,12 +74,12 @@ function App() {
             </ProtectedRoute>
           } />
           <Route path="company-admin" element={
-            <ProtectedRoute requiredGroups={["partnerAdmin"]}>
+            <ProtectedRoute requiredGroups={["companyAdmin"]}>
               <OrganizationPage />
             </ProtectedRoute>
           } />
           <Route path="company-admin-tools" element={
-            <ProtectedRoute requiredGroups={["partnerAdmin"]}>
+            <ProtectedRoute requiredGroups={["companyAdmin"]}>
               <CompanyAdminPage />
             </ProtectedRoute>
           } />
@@ -93,7 +93,7 @@ function App() {
               <AdminPage />
             </ProtectedRoute>
           } />
-          <Route path="partners/:partnerId" element={<PartnerDetailPage />} />
+          <Route path="partners/:companyId" element={<CompanyDetailPage />} />
         </Route>
         
         {/* Redirect root to login */}

--- a/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
+++ b/apps/frontend-app/src/__tests__/AdminAccess.test.tsx
@@ -104,7 +104,7 @@ describe('Admin access', () => {
     expect(screen.getByText(/admin dashboard/i)).toBeInTheDocument();
   });
 
-  it('shows partner creation form on admin dashboard', () => {
+  it('shows company creation form on admin dashboard', () => {
     vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
       ...baseAuth,
       user: {
@@ -122,6 +122,6 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('heading', { name: /create new partner/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /create new company/i })).toBeInTheDocument();
   });
 });

--- a/apps/frontend-app/src/components/ReferralFormModal.tsx
+++ b/apps/frontend-app/src/components/ReferralFormModal.tsx
@@ -18,12 +18,12 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 interface ReferralFormModalProps {
-  partnerName: string | null;
+  companyName: string | null;
   isOpen: boolean;
   onClose: () => void;
 }
 
-const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOpen, onClose }) => {
+const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ companyName, isOpen, onClose }) => {
   const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
   });
@@ -42,7 +42,7 @@ const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOp
         return;
       }
       const formData = new URLSearchParams();
-      Object.entries({ ...data, source: partnerName }).forEach(([key, value]) => {
+      Object.entries({ ...data, source: companyName }).forEach(([key, value]) => {
         formData.append(key, String(value));
       });
       await fetch(webhookUrl, {
@@ -59,7 +59,7 @@ const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ partnerName, isOp
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={close} title={partnerName ? `Refer to ${partnerName}` : 'Refer Client'}>
+    <Modal isOpen={isOpen} onClose={close} title={companyName ? `Refer to ${companyName}` : 'Refer Client'}>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
         <Input label="Name" {...register('name')} error={errors.name?.message} />
         <Input label="Email" type="email" {...register('email')} error={errors.email?.message} />

--- a/apps/frontend-app/src/contexts/AuthContext.tsx
+++ b/apps/frontend-app/src/contexts/AuthContext.tsx
@@ -51,7 +51,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           firstName: attributes.given_name ?? 'User',
           lastName: attributes.family_name ?? '',
           email: attributes.email ?? currentUser.signInDetails?.loginId ?? '',
-          company: attributes['custom:partnerId'] ?? 'WFG',
+          company: attributes['custom:companyId'] ?? 'WFG',
           groups,
           uplineSMD: attributes['custom:uplineSMD'] || undefined,
           uplineEVC: attributes['custom:uplineEVC'] || undefined,
@@ -111,8 +111,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             email: userData.email,
             given_name: userData.firstName,
             family_name: userData.lastName,
-            // Map the selected company to the PartnerId custom attribute in Cognito
-            'custom:partnerId': userData.company,
+            // Map the selected company to the CompanyId custom attribute in Cognito
+            'custom:companyId': userData.company,
             'custom:uplineSMD': userData.uplineSMD || '',
             'custom:uplineEVC': userData.uplineEVC || '',
           },
@@ -147,7 +147,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         attributes['family_name'] = updates.lastName;
       }
       if (updates.company !== undefined) {
-        attributes['custom:partnerId'] = updates.company;
+        attributes['custom:companyId'] = updates.company;
       }
       if (updates.email !== undefined) {
         attributes['email'] = updates.email;

--- a/apps/frontend-app/src/data/companiesData.tsx
+++ b/apps/frontend-app/src/data/companiesData.tsx
@@ -9,7 +9,7 @@ import {
   Users
 } from 'lucide-react';
 
-export type Partner = {
+export type Company = {
   id: string;
   name: string;
   description: string;
@@ -27,7 +27,7 @@ export type Partner = {
   };
 };
 
-export const partnersData: Partner[] = [
+export const companiesData: Company[] = [
   {
     id: 'sunny-hill',
     name: 'Sunny Hill Financial',

--- a/apps/frontend-app/src/data/companyAggregateStats.ts
+++ b/apps/frontend-app/src/data/companyAggregateStats.ts
@@ -1,11 +1,11 @@
-export type PartnerAggregateStats = {
+export type CompanyAggregateStats = {
   totalEarnings: number;
   pendingCommissions: number;
   referralsCount: number;
   successfulReferrals: number;
 };
 
-export const partnerAggregateStats: Record<string, PartnerAggregateStats> = {
+export const companyAggregateStats: Record<string, CompanyAggregateStats> = {
   'sunny-hill': {
     totalEarnings: 125000,
     pendingCommissions: 6200,

--- a/apps/frontend-app/src/pages/LoginPage.tsx
+++ b/apps/frontend-app/src/pages/LoginPage.tsx
@@ -153,7 +153,7 @@ const LoginPage = () => {
                   <Building size={24} />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-xl">Strategic Partnerships</h3>
+                  <h3 className="font-semibold text-xl">Strategic Companies</h3>
                   <p className="text-white/80 mt-1">Connect with industry-leading financial service providers</p>
                 </div>
               </div>

--- a/apps/frontend-app/src/pages/dashboard/AdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/AdminPage.tsx
@@ -7,12 +7,12 @@ import type { Schema } from '../../amplify/data/resource';
 import { Input } from '../../components/ui/Input';
 import { Button } from '../../components/ui/Button';
 import { toast } from '../../components/ui/Toaster';
-import { invitePartnerAdmin } from '../../utils/invitePartnerAdmin';
+import { inviteCompanyAdmin } from '../../utils/inviteCompanyAdmin';
 
 const client = generateClient<Schema>();
 
-const partnerSchema = z.object({
-  name: z.string().min(1, 'Partner name is required'),
+const companySchema = z.object({
+  name: z.string().min(1, 'Company name is required'),
   contactEmail: z.string().email('Valid email required'),
   website: z.string().url('Valid URL required'),
   adminFirstName: z.string().min(1, 'First name required'),
@@ -20,50 +20,50 @@ const partnerSchema = z.object({
   adminEmail: z.string().email('Valid email required'),
 });
 
-type PartnerFormValues = z.infer<typeof partnerSchema>;
+type CompanyFormValues = z.infer<typeof companySchema>;
 
 const AdminPage = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [partners, setPartners] = useState<Schema['Partner']['type'][]>([]);
-  const { register, handleSubmit, formState: { errors } } = useForm<PartnerFormValues>({
-    resolver: zodResolver(partnerSchema),
+  const [companies, setCompanies] = useState<Schema['Company']['type'][]>([]);
+  const { register, handleSubmit, formState: { errors } } = useForm<CompanyFormValues>({
+    resolver: zodResolver(companySchema),
   });
 
   useEffect(() => {
-    const fetchPartners = async () => {
+    const fetchCompanies = async () => {
       try {
-        const { data } = await client.models.Partner.list();
-        setPartners(data);
+        const { data } = await client.models.Company.list();
+        setCompanies(data);
       } catch (error) {
-        console.error('Failed to load partners', error);
+        console.error('Failed to load companies', error);
       }
     };
-    fetchPartners();
+    fetchCompanies();
   }, []);
 
-  const onSubmit = async (data: PartnerFormValues) => {
+  const onSubmit = async (data: CompanyFormValues) => {
     setIsSubmitting(true);
     try {
-      const { data: partner } = await client.models.Partner.create({
+      const { data: company } = await client.models.Company.create({
         name: data.name,
         contactEmail: data.contactEmail,
         website: data.website,
         status: 'ACTIVE',
       });
 
-      setPartners((prev) => [...prev, partner]);
+      setCompanies((prev) => [...prev, company]);
 
-      await invitePartnerAdmin({
+      await inviteCompanyAdmin({
         email: data.adminEmail,
         firstName: data.adminFirstName,
         lastName: data.adminLastName,
-        partnerId: partner.id,
+        companyId: company.id,
       });
 
-      toast.success('Partner created', 'Invitation sent to partner admin');
+      toast.success('Company created', 'Invitation sent to company admin');
     } catch (err) {
       console.error(err);
-      toast.error('Failed to create partner');
+      toast.error('Failed to create company');
     } finally {
       setIsSubmitting(false);
     }
@@ -78,9 +78,9 @@ const AdminPage = () => {
         </p>
       </div>
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-        <h2 className="text-xl font-semibold mb-4">Create New Partner</h2>
+        <h2 className="text-xl font-semibold mb-4">Create New Company</h2>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <Input label="Partner Name" {...register('name')} error={errors.name?.message} />
+          <Input label="Company Name" {...register('name')} error={errors.name?.message} />
           <Input label="Contact Email" {...register('contactEmail')} error={errors.contactEmail?.message} />
           <Input label="Website" {...register('website')} error={errors.website?.message} />
           <hr className="my-4" />
@@ -90,16 +90,16 @@ const AdminPage = () => {
           </div>
           <Input label="Admin Email" {...register('adminEmail')} error={errors.adminEmail?.message} />
           <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? 'Creating...' : 'Create Partner'}
+            {isSubmitting ? 'Creating...' : 'Create Company'}
           </Button>
         </form>
       </div>
 
-      {partners.length > 0 && (
+      {companies.length > 0 && (
         <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <h2 className="text-xl font-semibold mb-4">Existing Partners</h2>
+          <h2 className="text-xl font-semibold mb-4">Existing Companies</h2>
           <ul className="space-y-2">
-            {partners.map((p) => (
+            {companies.map((p) => (
               <li key={p.id} className="flex justify-between">
                 <span>{p.name}</span>
                 <span className="text-sm text-gray-500">{p.status}</span>

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -151,7 +151,7 @@ const BusinessPage = () => {
           <div className="text-center md:text-left">
             <h2 className="text-xl font-bold text-white">Ready to increase your earnings?</h2>
             <p className="mt-1 text-primary-foreground text-opacity-90">
-              Refer clients to our strategic partners and earn commissions.
+              Refer clients to our strategic companies and earn commissions.
             </p>
           </div>
           <div className="mt-6 md:mt-0">

--- a/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyAdminPage.tsx
@@ -95,14 +95,14 @@ const CompanyAdminPage = () => {
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Organization Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">Manage partner companies and referral settings.</p>
+        <p className="mt-1 text-sm text-gray-500">Manage companies and referral settings.</p>
       </div>
 
       <StatsOverview stats={stats} />
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Partner Earnings Overview</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Company Earnings Overview</h2>
           <div>
             <select
               className="py-1 px-3 border border-gray-300 rounded-md text-sm"
@@ -136,7 +136,7 @@ const CompanyAdminPage = () => {
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100 space-y-4">
         <p className="text-gray-700">
-          This page is accessible to Partner Admins and Site Admins. Manage company settings, partner configurations, and referral workflows here.
+          This page is accessible to Company Admins and Site Admins. Manage company settings, company configurations, and referral workflows here.
         </p>
         <div>
           <p className="text-sm text-gray-500">Webhook Endpoint:</p>

--- a/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
@@ -12,20 +12,20 @@ import {
   Link2
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
-import { partnersData } from '../../data/partnersData';
+import { companiesData } from '../../data/companiesData';
 import { toast } from '../../components/ui/Toaster';
 import StatsOverview, { StatItem } from '../../components/StatsOverview';
-import { partnerAggregateStats } from '../../data/partnerAggregateStats';
+import { companyAggregateStats } from '../../data/companyAggregateStats';
 
-const PartnerDetailPage = () => {
-  const { partnerId } = useParams<{ partnerId: string }>();
+const CompanyDetailPage = () => {
+  const { companyId } = useParams<{ companyId: string }>();
   const navigate = useNavigate();
-  
-  const partner = useMemo(() => {
-    return partnersData.find(p => p.id === partnerId);
-  }, [partnerId]);
 
-  const aggregate = partnerAggregateStats[partnerId || ''];
+  const company = useMemo(() => {
+    return companiesData.find(p => p.id === companyId);
+  }, [companyId]);
+
+  const aggregate = companyAggregateStats[companyId || ''];
 
   const stats: StatItem[] = useMemo(() => {
     if (!aggregate) return [];
@@ -63,7 +63,7 @@ const PartnerDetailPage = () => {
     ];
   }, [aggregate]);
 
-  if (!partner) {
+  if (!company) {
     navigate('/dashboard/learn');
     return null;
   }
@@ -103,8 +103,8 @@ const PartnerDetailPage = () => {
   // Mock FAQ items
   const faqItems = [
     {
-      question: 'What services does this partner provide?',
-      answer: `${partner.name} provides ${partner.tags.join(', ')} services. ${partner.description}`
+      question: 'What services does this company provide?',
+      answer: `${company.name} provides ${company.tags.join(', ')} services. ${company.description}`
     },
     {
       question: 'How are commissions calculated?',
@@ -135,35 +135,35 @@ const PartnerDetailPage = () => {
         </Button>
         
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{partner.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{company.name}</h1>
           <p className="text-sm text-gray-500">
-            {partner.tags.join(' • ')}
+            {company.tags.join(' • ')}
           </p>
         </div>
       </div>
 
       {stats.length > 0 && <StatsOverview stats={stats} />}
 
-      {/* Partner overview */}
+      {/* Company overview */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
         <div className="md:flex">
           <div className="md:flex-shrink-0 flex items-center justify-center p-8 bg-gray-50 md:w-64">
             <div 
               className="w-24 h-24 rounded-full flex items-center justify-center"
-              style={{ backgroundColor: partner.bgColor || '#f3f4f6' }}
+              style={{ backgroundColor: company.bgColor || '#f3f4f6' }}
             >
-              {React.cloneElement(partner.icon as React.ReactElement, { size: 48 })}
+              {React.cloneElement(company.icon as React.ReactElement, { size: 48 })}
             </div>
           </div>
           
           <div className="p-8 flex-1">
-            <h2 className="text-xl font-semibold text-gray-900">About {partner.name}</h2>
+            <h2 className="text-xl font-semibold text-gray-900">About {company.name}</h2>
             <p className="mt-4 text-gray-600">
-              {partner.fullDescription || partner.description}
+              {company.fullDescription || company.description}
             </p>
             
             <div className="mt-6 flex flex-wrap gap-2">
-              {partner.tags.map((tag, index) => (
+              {company.tags.map((tag, index) => (
                 <span 
                   key={index} 
                   className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800"
@@ -175,7 +175,7 @@ const PartnerDetailPage = () => {
             
             <div className="mt-8 flex flex-col sm:flex-row gap-4">
               <a 
-                href={partner.websiteUrl || '#'} 
+                href={company.websiteUrl || '#'} 
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="inline-block"
@@ -187,7 +187,7 @@ const PartnerDetailPage = () => {
               </a>
               
               <a 
-                href={partner.referralUrl} 
+                href={company.referralUrl} 
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="inline-block"
@@ -213,7 +213,7 @@ const PartnerDetailPage = () => {
               <h3 className="text-lg font-medium">Commission Rate</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {partner.commissionInfo?.rate || '15-20%'}
+              {company.commissionInfo?.rate || '15-20%'}
             </p>
             <p className="mt-2 text-sm text-gray-500">
               Of the service value
@@ -226,7 +226,7 @@ const PartnerDetailPage = () => {
               <h3 className="text-lg font-medium">Average Payout</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {partner.commissionInfo?.average || '$500-$1,200'}
+              {company.commissionInfo?.average || '$500-$1,200'}
             </p>
             <p className="mt-2 text-sm text-gray-500">
               Per successful referral
@@ -250,7 +250,7 @@ const PartnerDetailPage = () => {
             variant="outline"
             className="flex items-center"
             onClick={() => {
-              navigator.clipboard.writeText(`${window.location.origin}/r/${partner.id}`);
+              navigator.clipboard.writeText(`${window.location.origin}/r/${company.id}`);
               toast.success("Referral link copied!", "You can now share this with your clients.");
             }}
           >
@@ -322,12 +322,12 @@ const PartnerDetailPage = () => {
           <div className="text-center md:text-left">
             <h2 className="text-xl font-bold text-white">Ready to start referring?</h2>
             <p className="mt-1 text-primary-foreground text-opacity-90">
-              Start earning commissions by referring clients to {partner.name}.
+              Start earning commissions by referring clients to {company.name}.
             </p>
           </div>
           <div className="mt-6 md:mt-0">
             <a 
-              href={partner.referralUrl} 
+              href={company.referralUrl} 
               target="_blank" 
               rel="noopener noreferrer"
               className="inline-block"
@@ -343,4 +343,4 @@ const PartnerDetailPage = () => {
   );
 };
 
-export default PartnerDetailPage;
+export default CompanyDetailPage;

--- a/apps/frontend-app/src/pages/dashboard/LearnPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/LearnPage.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ExternalLink, BookOpen, Video, FileText, Bookmark } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
-import { partnersData } from '../../data/partnersData';
+import { companiesData } from '../../data/companiesData';
 
 const LearnPage = () => {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Learn About Our Partners</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Learn About Our Companies</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Discover our strategic partners and how to effectively refer clients
+          Discover our strategic companies and how to effectively refer clients
         </p>
       </div>
       
@@ -24,7 +24,7 @@ const LearnPage = () => {
             <div className="uppercase tracking-wide text-sm text-primary font-semibold">Featured Resource</div>
             <h2 className="mt-2 text-xl font-semibold text-gray-900">Complete Guide to Successful Referrals</h2>
             <p className="mt-3 text-gray-500">
-              Learn how to identify the right opportunities, position our partners' services effectively, and maximize your commissions.
+              Learn how to identify the right opportunities, position our companies' services effectively, and maximize your commissions.
             </p>
             <div className="mt-4">
               <Button className="inline-flex items-center">
@@ -36,18 +36,18 @@ const LearnPage = () => {
         </div>
       </div>
       
-      {/* Partner grid */}
+      {/* Company grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {partnersData.map((partner) => (
-          <div key={partner.id} className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
+        {companiesData.map((company) => (
+          <div key={company.id} className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
             <div className="p-6">
               <div className="flex justify-between items-start">
                 <div className="flex-shrink-0">
                   <div 
                     className="w-12 h-12 rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: partner.bgColor || '#f3f4f6' }}
+                    style={{ backgroundColor: company.bgColor || '#f3f4f6' }}
                   >
-                    {partner.icon}
+                    {company.icon}
                   </div>
                 </div>
                 <Button variant="ghost" size="sm" className="text-gray-500" title="Save for later">
@@ -55,13 +55,13 @@ const LearnPage = () => {
                 </Button>
               </div>
               
-              <h3 className="mt-4 text-lg font-medium text-gray-900">{partner.name}</h3>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">{company.name}</h3>
               <p className="mt-2 text-sm text-gray-500 line-clamp-3">
-                {partner.description}
+                {company.description}
               </p>
               
               <div className="mt-4 flex flex-wrap gap-2">
-                {partner.tags.map((tag, index) => (
+                {company.tags.map((tag, index) => (
                   <span 
                     key={index} 
                     className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
@@ -73,20 +73,20 @@ const LearnPage = () => {
               
               <div className="mt-6 flex justify-between items-center">
                 <div className="flex space-x-2">
-                  {partner.hasTraining && (
+                  {company.hasTraining && (
                     <span title="Training available" className="text-primary">
                       <Video className="h-5 w-5" />
                     </span>
                   )}
-                  {partner.hasDocumentation && (
+                  {company.hasDocumentation && (
                     <span title="Documentation available" className="text-primary">
                       <FileText className="h-5 w-5" />
                     </span>
                   )}
                 </div>
                 
-                <Link 
-                  to={`/dashboard/partners/${partner.id}`}
+                <Link
+                  to={`/dashboard/companies/${company.id}`}
                   className="text-sm font-medium text-primary hover:text-primary/80 flex items-center"
                 >
                   Learn more

--- a/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
@@ -95,14 +95,14 @@ const OrganizationPage = () => {
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Organization Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">Manage partner companies and referral settings.</p>
+        <p className="mt-1 text-sm text-gray-500">Manage companies and referral settings.</p>
       </div>
 
       <StatsOverview stats={stats} />
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Partner Earnings Overview</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Company Earnings Overview</h2>
           <div>
             <select
               className="py-1 px-3 border border-gray-300 rounded-md text-sm"
@@ -136,7 +136,7 @@ const OrganizationPage = () => {
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100 space-y-4">
         <p className="text-gray-700">
-          This page is accessible to Partner Admins and Site Admins. Manage company settings, partner configurations, and referral workflows here.
+          This page is accessible to Company Admins and Site Admins. Manage company settings, company configurations, and referral workflows here.
         </p>
         <div>
           <p className="text-sm text-gray-500">Webhook Endpoint:</p>

--- a/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
@@ -7,25 +7,25 @@ import {
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
-import { partnersData } from '../../data/partnersData';
+import { companiesData } from '../../data/companiesData';
 import { toast } from '../../components/ui/Toaster';
 import ReferralFormModal from '../../components/ReferralFormModal';
 
 const ReferPage = () => {
   const [search, setSearch] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [activePartner, setActivePartner] = useState<string | null>(null);
+  const [activeCompany, setActiveCompany] = useState<string | null>(null);
   
-  // Derive categories from partners data
+  // Derive categories from companies data
   const categories = Array.from(
-    new Set(partnersData.flatMap(partner => partner.tags))
+    new Set(companiesData.flatMap(company => company.tags))
   );
-  
-  // Filter partners based on search and category
-  const filteredPartners = partnersData.filter(partner => {
-    const matchesSearch = partner.name.toLowerCase().includes(search.toLowerCase()) || 
-                         partner.description.toLowerCase().includes(search.toLowerCase());
-    const matchesCategory = selectedCategory ? partner.tags.includes(selectedCategory) : true;
+
+  // Filter companies based on search and category
+  const filteredCompanies = companiesData.filter(company => {
+    const matchesSearch = company.name.toLowerCase().includes(search.toLowerCase()) ||
+                         company.description.toLowerCase().includes(search.toLowerCase());
+    const matchesCategory = selectedCategory ? company.tags.includes(selectedCategory) : true;
     return matchesSearch && matchesCategory;
   });
   
@@ -34,7 +34,7 @@ const ReferPage = () => {
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Refer Clients</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Connect your clients with our strategic partners and earn commissions
+          Connect your clients with our strategic companies and earn commissions
         </p>
       </div>
       
@@ -44,7 +44,7 @@ const ReferPage = () => {
           <div className="md:w-1/3">
             <Input
               type="search"
-              placeholder="Search partners..."
+              placeholder="Search companies..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full"
@@ -74,42 +74,42 @@ const ReferPage = () => {
         </div>
       </div>
       
-      {/* Partners grid */}
+      {/* Companies grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {filteredPartners.map((partner) => (
-          <div key={partner.id} className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
+        {filteredCompanies.map((company) => (
+          <div key={company.id} className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
             <div className="p-6">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
                   <div 
                     className="w-12 h-12 rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: partner.bgColor || '#f3f4f6' }}
+                    style={{ backgroundColor: company.bgColor || '#f3f4f6' }}
                   >
-                    {partner.icon}
+                    {company.icon}
                   </div>
                 </div>
                 <div className="ml-4">
-                  <h3 className="text-lg font-medium text-gray-900">{partner.name}</h3>
+                  <h3 className="text-lg font-medium text-gray-900">{company.name}</h3>
                   <p className="text-sm text-gray-500">
-                    {partner.tags.join(' • ')}
+                    {company.tags.join(' • ')}
                   </p>
                 </div>
               </div>
               
               <p className="mt-4 text-sm text-gray-500 line-clamp-3">
-                {partner.description}
+                {company.description}
               </p>
               
-              {partner.commissionInfo && (
+              {company.commissionInfo && (
                 <div className="mt-4 bg-gray-50 rounded-md p-4">
                   <div className="flex items-center space-x-4">
                     <div className="flex items-center">
                       <BadgePercent className="h-5 w-5 text-primary mr-1" />
-                      <span className="text-sm text-gray-700">{partner.commissionInfo.rate}</span>
+                      <span className="text-sm text-gray-700">{company.commissionInfo.rate}</span>
                     </div>
                     <div className="flex items-center">
                       <CircleDollarSign className="h-5 w-5 text-success mr-1" />
-                      <span className="text-sm text-gray-700">{partner.commissionInfo.average}</span>
+                      <span className="text-sm text-gray-700">{company.commissionInfo.average}</span>
                     </div>
                   </div>
                 </div>
@@ -121,7 +121,7 @@ const ReferPage = () => {
                   size="sm"
                   className="flex items-center justify-center"
                   onClick={() => {
-                    navigator.clipboard.writeText(`${window.location.origin}/r/${partner.id}`);
+                    navigator.clipboard.writeText(`${window.location.origin}/r/${company.id}`);
                     toast.success("Referral link copied!", "You can now share this with your clients.");
                   }}
                 >
@@ -132,7 +132,7 @@ const ReferPage = () => {
                 <Button
                   className="w-full flex items-center justify-center"
                   size="sm"
-                  onClick={() => setActivePartner(partner.name)}
+                  onClick={() => setActiveCompany(company.name)}
                 >
                   <Send className="mr-1 h-4 w-4" />
                   Refer Now
@@ -143,9 +143,9 @@ const ReferPage = () => {
         ))}
       </div>
       
-      {filteredPartners.length === 0 && (
+      {filteredCompanies.length === 0 && (
         <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-8 text-center">
-          <p className="text-gray-500">No partners found matching your criteria.</p>
+          <p className="text-gray-500">No companies found matching your criteria.</p>
           <Button 
             variant="outline" 
             className="mt-4"
@@ -192,9 +192,9 @@ const ReferPage = () => {
         </div>
       </div>
       <ReferralFormModal
-        partnerName={activePartner}
-        isOpen={Boolean(activePartner)}
-        onClose={() => setActivePartner(null)}
+        companyName={activeCompany}
+        isOpen={Boolean(activeCompany)}
+        onClose={() => setActiveCompany(null)}
       />
     </div>
   );

--- a/apps/frontend-app/src/pages/dashboard/SiteAdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/SiteAdminPage.tsx
@@ -95,14 +95,14 @@ const SiteAdminPage = () => {
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Organization Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">Manage partner companies and referral settings.</p>
+        <p className="mt-1 text-sm text-gray-500">Manage companies and referral settings.</p>
       </div>
 
       <StatsOverview stats={stats} />
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Partner Earnings Overview</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Company Earnings Overview</h2>
           <div>
             <select
               className="py-1 px-3 border border-gray-300 rounded-md text-sm"
@@ -136,7 +136,7 @@ const SiteAdminPage = () => {
 
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100 space-y-4">
         <p className="text-gray-700">
-          This page is accessible to Partner Admins and Site Admins. Manage company settings, partner configurations, and referral workflows here.
+          This page is accessible to Company Admins and Site Admins. Manage company settings, company configurations, and referral workflows here.
         </p>
         <div>
           <p className="text-sm text-gray-500">Webhook Endpoint:</p>

--- a/apps/frontend-app/src/pages/dashboard/TeamPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/TeamPage.tsx
@@ -151,7 +151,7 @@ const TeamPage = () => {
           <div className="text-center md:text-left">
             <h2 className="text-xl font-bold text-white">Ready to increase your earnings?</h2>
             <p className="mt-1 text-primary-foreground text-opacity-90">
-              Refer clients to our strategic partners and earn commissions.
+              Refer clients to our strategic companies and earn commissions.
             </p>
           </div>
           <div className="mt-6 md:mt-0">

--- a/apps/frontend-app/src/utils/inviteCompanyAdmin.ts
+++ b/apps/frontend-app/src/utils/inviteCompanyAdmin.ts
@@ -1,15 +1,15 @@
 import { CognitoIdentityProviderClient, AdminCreateUserCommand, AdminAddUserToGroupCommand } from '@aws-sdk/client-cognito-identity-provider';
 
-export async function invitePartnerAdmin({
+export async function inviteCompanyAdmin({
   email,
   firstName,
   lastName,
-  partnerId,
+  companyId,
 }: {
   email: string;
   firstName: string;
   lastName: string;
-  partnerId: string;
+  companyId: string;
 }) {
   const region = import.meta.env.VITE_AWS_REGION;
   const userPoolId = import.meta.env.VITE_COGNITO_USER_POOL_ID;
@@ -29,7 +29,7 @@ export async function invitePartnerAdmin({
         { Name: 'email_verified', Value: 'true' },
         { Name: 'given_name', Value: firstName },
         { Name: 'family_name', Value: lastName },
-        { Name: 'custom:partnerId', Value: partnerId },
+        { Name: 'custom:companyId', Value: companyId },
       ],
     })
   );
@@ -38,7 +38,7 @@ export async function invitePartnerAdmin({
     new AdminAddUserToGroupCommand({
       UserPoolId: userPoolId,
       Username: email,
-      GroupName: 'partnerAdmin',
+      GroupName: 'companyAdmin',
     })
   );
 }


### PR DESCRIPTION
## Summary
- rename Partner table to Company
- update Amplify schema and backend function references
- update frontend components, routes, and utilities
- adjust text labels and tests for new terminology

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684af36eb4508332ade93b37a25d7fac