### PR TITLE
Fix Amplify schema export

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -1,7 +1,8 @@
 import { defineData, a } from '@aws-amplify/backend';
+import type { ClientSchema } from '@aws-amplify/backend';
 import { updateReferralStatusWebhook } from "../functions/updateReferralStatusWebhook/resource";
 
-const schema = a.schema({
+export const schema = a.schema({
   // Company model
   Company: a.model({
     id: a.id(),
@@ -83,6 +84,8 @@ const schema = a.schema({
     allow.group('orgLead').to(['update','read'])
   ])
 });
+
+export type Schema = ClientSchema<typeof schema>;
 
 export const data = defineData({
   schema,


### PR DESCRIPTION
## Summary
- export the data schema and Schema type so Amplify functions can import it

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684b5239ceb88332999ea12dbc1bae2e