### PR TITLE
Add partner seeding models

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -1,111 +1,151 @@
-import { defineData, a } from '@aws-amplify/backend';
-import type { ClientSchema } from '@aws-amplify/backend';
+import { defineData, a } from "@aws-amplify/backend";
+import type { ClientSchema } from "@aws-amplify/backend";
 import { updateReferralStatusWebhook } from "../functions/updateReferralStatusWebhook/resource";
 
 export const schema = a.schema({
   // Company model
-  Company: a.model({
-    id: a.id(),
-    companyName: a.string().required(),
-    contactEmail: a.string().required(),
-    website: a.string().required(),
-    status: a.string().required(),
-    description: a.string(),
-    compensation: a.customType({
-      agentPercentage: a.float(),
-      teamLeadPercentage: a.float(),
-      orgLeadPercentage: a.float(),
-      bonusPoolPercentage: a.float(),
-      mrnPercentage: a.float(),
-      contracterPercentage: a.float()
-    }),
-    trainingLinks: a.string().array(),
-    orgId: a.string(),
-    webhookApiKeyHash: a.string(),
-    createdAt: a.string().required(),
-    updatedAt: a.string(),
-    // Relationships
-    users: a.hasMany('User', 'companyId'),
-    referrals: a.hasMany('Referral', 'companyId')
-  }).authorization((allow) => [
-    allow.guest().to(['read']),
-    allow.group('admin').to(['create', 'read', 'update', 'delete']),
-    allow.group('companyAdmin').to(['read', 'update']),
-    // Allow API key for seed scripts
-    allow.publicApiKey().to(['create', 'read', 'update', 'delete'])
-  ]),
+  Company: a
+    .model({
+      id: a.id(),
+      companyName: a.string().required(),
+      contactEmail: a.string().required(),
+      website: a.string().required(),
+      status: a.string().required(),
+      description: a.string(),
+      compensation: a.customType({
+        agentPercentage: a.float(),
+        teamLeadPercentage: a.float(),
+        orgLeadPercentage: a.float(),
+        bonusPoolPercentage: a.float(),
+        mrnPercentage: a.float(),
+        contracterPercentage: a.float(),
+      }),
+      trainingLinks: a.string().array(),
+      orgId: a.string(),
+      webhookApiKeyHash: a.string(),
+      createdAt: a.string().required(),
+      updatedAt: a.string(),
+      // Relationships
+      users: a.hasMany("User", "companyId"),
+      referrals: a.hasMany("Referral", "companyId"),
+    })
+    .authorization((allow) => [
+      allow.guest().to(["read"]),
+      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.group("companyAdmin").to(["read", "update"]),
+      // Allow API key for seed scripts
+      allow.publicApiKey().to(["create", "read", "update", "delete"]),
+    ]),
 
   // User model (extends Cognito user)
-  User: a.model({
-    id: a.id(), // Maps to Cognito sub
-    name: a.string().required(),
-    email: a.string().required(),
-    phone: a.string(),
-    address: a.string(),
-    teamId: a.string(),
-    teamLead: a.boolean(),
-    teamLeadId: a.string(),
-    orgLeadId: a.string(),
-    bankInfoDocument: a.string(),
-    taxDocument: a.string(),
-    // Company relationship
-    companyId: a.id(),
-    company: a.belongsTo('Company', 'companyId'),
-    // Referrals relationship
-    referrals: a.hasMany('Referral', 'userId'),
-    createdAt: a.string().required(),
-    updatedAt: a.string()
-  }).authorization((allow) => [
-    allow.owner().to(['read']),
-    allow.group('admin').to(['create', 'read', 'update', 'delete']),
-    allow.group('teamLead').to(['read']),
-    allow.group('orgLead').to(['update','read']),
-    allow.group('companyAdmin').to(['create', 'read', 'update', 'delete']),
-    // Allow API key for seed scripts
-    allow.publicApiKey().to(['create', 'read', 'update', 'delete'])
-  ]),
+  User: a
+    .model({
+      id: a.id(), // Maps to Cognito sub
+      name: a.string().required(),
+      email: a.string().required(),
+      phone: a.string(),
+      address: a.string(),
+      teamId: a.string(),
+      teamLead: a.boolean(),
+      teamLeadId: a.string(),
+      orgLeadId: a.string(),
+      bankInfoDocument: a.string(),
+      taxDocument: a.string(),
+      // Company relationship
+      companyId: a.id(),
+      company: a.belongsTo("Company", "companyId"),
+      // Referrals relationship
+      referrals: a.hasMany("Referral", "userId"),
+      createdAt: a.string().required(),
+      updatedAt: a.string(),
+    })
+    .authorization((allow) => [
+      allow.owner().to(["read"]),
+      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.group("teamLead").to(["read"]),
+      allow.group("orgLead").to(["update", "read"]),
+      allow.group("companyAdmin").to(["create", "read", "update", "delete"]),
+      // Allow API key for seed scripts
+      allow.publicApiKey().to(["create", "read", "update", "delete"]),
+    ]),
 
   // Referral model
-  Referral: a.model({
-    id: a.id(),
-    companyId: a.string().required(),
-    name: a.string().required(),
-    email: a.string().required(),
-    phoneNumber: a.string(),
-    approximateValue: a.float(),
-    userId: a.string().required(),
-    status: a.enum(['IN_PROGRESS', 'IN_REVIEW', 'PAID', 'REJECTED']),
-    notes: a.string(),
-    // Payment information
-    paymentId: a.string(),
-    amount: a.float(),
-    type: a.enum(['COMMISSION', 'BONUS_POOL', 'UPLINE']),
-    paymentType: a.enum(['COMMISSION', 'BONUS_POOL', 'UPLINE']),
-    paymentStatus: a.enum(['PENDING', 'PROCESSED', 'FAILED']),
-    period: a.string(), // YYYY-MM format
-    processedAt: a.string(),
-    bankInfo: a.customType({
-      accountNumber: a.string(),
-      routingNumber: a.string(),
-      accountType: a.string()
-    }),
-    // Split referral information
-    splitUserIds: a.string().array(),
-    // Relationships
-    user: a.belongsTo('User', 'userId'),
-    company: a.belongsTo('Company', 'companyId'),
-    teamLeadId: a.string(),
-    orgLeadId: a.string(),
-    createdAt: a.string().required(),
-    updatedAt: a.string()
-  }).authorization((allow) => [
-    allow.owner().to(['create', 'read', 'update']),
-    allow.group('admin').to(['create', 'read', 'update', 'delete']),
-    allow.group('teamLead').to(['update','read']),
-    allow.group('orgLead').to(['update','read']),
-    // Allow API key for seed scripts
-    allow.publicApiKey().to(['create', 'read', 'update', 'delete'])
-  ])
+  Referral: a
+    .model({
+      id: a.id(),
+      companyId: a.string().required(),
+      name: a.string().required(),
+      email: a.string().required(),
+      phoneNumber: a.string(),
+      approximateValue: a.float(),
+      userId: a.string().required(),
+      status: a.enum(["IN_PROGRESS", "IN_REVIEW", "PAID", "REJECTED"]),
+      notes: a.string(),
+      // Payment information
+      paymentId: a.string(),
+      amount: a.float(),
+      type: a.enum(["COMMISSION", "BONUS_POOL", "UPLINE"]),
+      paymentType: a.enum(["COMMISSION", "BONUS_POOL", "UPLINE"]),
+      paymentStatus: a.enum(["PENDING", "PROCESSED", "FAILED"]),
+      period: a.string(), // YYYY-MM format
+      processedAt: a.string(),
+      bankInfo: a.customType({
+        accountNumber: a.string(),
+        routingNumber: a.string(),
+        accountType: a.string(),
+      }),
+      // Split referral information
+      splitUserIds: a.string().array(),
+      // Relationships
+      user: a.belongsTo("User", "userId"),
+      company: a.belongsTo("Company", "companyId"),
+      teamLeadId: a.string(),
+      orgLeadId: a.string(),
+      createdAt: a.string().required(),
+      updatedAt: a.string(),
+    })
+    .authorization((allow) => [
+      allow.owner().to(["create", "read", "update"]),
+      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.group("teamLead").to(["update", "read"]),
+      allow.group("orgLead").to(["update", "read"]),
+      // Allow API key for seed scripts
+      allow.publicApiKey().to(["create", "read", "update", "delete"]),
+    ]),
+
+  // Training resource model
+  TrainingResource: a
+    .model({
+      id: a.id(),
+      companyId: a.string().required(),
+      title: a.string().required(),
+      type: a.enum(["video", "document"]),
+      url: a.string().required(),
+      duration: a.string(),
+      company: a.belongsTo("Company", "companyId"),
+      createdAt: a.string().required(),
+      updatedAt: a.string(),
+    })
+    .authorization((allow) => [
+      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.publicApiKey().to(["create", "read", "update", "delete"]),
+    ]),
+
+  // FAQ model
+  FaqItem: a
+    .model({
+      id: a.id(),
+      companyId: a.string().required(),
+      question: a.string().required(),
+      answer: a.string().required(),
+      company: a.belongsTo("Company", "companyId"),
+      createdAt: a.string().required(),
+      updatedAt: a.string(),
+    })
+    .authorization((allow) => [
+      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.publicApiKey().to(["create", "read", "update", "delete"]),
+    ]),
 });
 
 export type Schema = ClientSchema<typeof schema>;
@@ -120,8 +160,8 @@ export const data = defineData({
     },
   },
   functions: {
-    updateReferralStatusWebhook
-  }
+    updateReferralStatusWebhook,
+  },
 });
 
 /*== STEP 2 ===============================================================

--- a/apps/frontend-app/amplify/data/seed.ts
+++ b/apps/frontend-app/amplify/data/seed.ts
@@ -1,176 +1,180 @@
-import { generateClient } from 'aws-amplify/data';
-import type { Schema } from './resource';
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "./resource";
 
 // Use API key authentication for seed scripts
 const client = generateClient<Schema>({
-  authMode: 'apiKey'
+  authMode: "apiKey",
 });
 
 export async function seedData() {
-  console.log('🌱 Starting data seeding...');
+  console.log("🌱 Starting data seeding...");
 
   try {
     // Create test companies based on companyMeta.tsx
     const companies = [
       {
-        companyName: 'Sunny Hill Financial',
-        contactEmail: 'admin@sunnyhillfinancial.com',
-        website: 'https://sunnyhillfinancial.com',
-        status: 'ACTIVE',
-        description: 'Comprehensive financial planning, investment, and retirement services',
+        companyName: "Sunny Hill Financial",
+        contactEmail: "admin@sunnyhillfinancial.com",
+        website: "https://sunnyhillfinancial.com",
+        status: "ACTIVE",
+        description:
+          "Comprehensive financial planning, investment, and retirement services",
         compensation: {
           agentPercentage: 45.0,
           teamLeadPercentage: 8.0,
           orgLeadPercentage: 5.0,
           bonusPoolPercentage: 15.0,
           mrnPercentage: 20.0,
-          contracterPercentage: 7.0
+          contracterPercentage: 7.0,
         },
         trainingLinks: [
-          'https://sunnyhillfinancial.com/training/financial-planning',
-          'https://sunnyhillfinancial.com/training/investment-basics'
+          "https://sunnyhillfinancial.com/training/financial-planning",
+          "https://sunnyhillfinancial.com/training/investment-basics",
         ],
-        orgId: 'ORG-SUNNY-001',
-        webhookApiKeyHash: 'test-webhook-hash-sunny',
+        orgId: "ORG-SUNNY-001",
+        webhookApiKeyHash: "test-webhook-hash-sunny",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'Prime Corporate Services',
-        contactEmail: 'contact@primecorporateservices.com',
-        website: 'https://www.primecorporateservices.com',
-        status: 'ACTIVE',
-        description: 'Business services including tax preparation, bookkeeping, and estate planning',
+        companyName: "Prime Corporate Services",
+        contactEmail: "contact@primecorporateservices.com",
+        website: "https://www.primecorporateservices.com",
+        status: "ACTIVE",
+        description:
+          "Business services including tax preparation, bookkeeping, and estate planning",
         compensation: {
           agentPercentage: 50.0,
           teamLeadPercentage: 10.0,
           orgLeadPercentage: 6.0,
           bonusPoolPercentage: 12.0,
           mrnPercentage: 18.0,
-          contracterPercentage: 4.0
+          contracterPercentage: 4.0,
         },
         trainingLinks: [
-          'https://www.primecorporateservices.com/training/business-services',
-          'https://www.primecorporateservices.com/training/tax-preparation'
+          "https://www.primecorporateservices.com/training/business-services",
+          "https://www.primecorporateservices.com/training/tax-preparation",
         ],
-        orgId: 'ORG-PRIME-002',
-        webhookApiKeyHash: 'test-webhook-hash-prime',
+        orgId: "ORG-PRIME-002",
+        webhookApiKeyHash: "test-webhook-hash-prime",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'ANCO Insurance',
-        contactEmail: 'info@anco.com',
-        website: 'https://www.anco.com',
-        status: 'ACTIVE',
-        description: 'Insurance solutions including employee benefits and business insurance',
+        companyName: "ANCO Insurance",
+        contactEmail: "info@anco.com",
+        website: "https://www.anco.com",
+        status: "ACTIVE",
+        description:
+          "Insurance solutions including employee benefits and business insurance",
         compensation: {
           agentPercentage: 48.0,
           teamLeadPercentage: 9.0,
           orgLeadPercentage: 5.5,
           bonusPoolPercentage: 20.0,
           mrnPercentage: 15.0,
-          contracterPercentage: 2.5
+          contracterPercentage: 2.5,
         },
-        trainingLinks: [
-          'https://www.anco.com/training/insurance-basics'
-        ],
-        orgId: 'ORG-ANCO-003',
-        webhookApiKeyHash: 'test-webhook-hash-anco',
+        trainingLinks: ["https://www.anco.com/training/insurance-basics"],
+        orgId: "ORG-ANCO-003",
+        webhookApiKeyHash: "test-webhook-hash-anco",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'Weightless Financial',
-        contactEmail: 'support@weightlessfinancial.com',
-        website: 'https://weightlessfinancial.com',
-        status: 'ACTIVE',
-        description: 'Debt resolution, financial education, and credit repair services',
+        companyName: "Weightless Financial",
+        contactEmail: "support@weightlessfinancial.com",
+        website: "https://weightlessfinancial.com",
+        status: "ACTIVE",
+        description:
+          "Debt resolution, financial education, and credit repair services",
         compensation: {
           agentPercentage: 42.0,
           teamLeadPercentage: 12.0,
           orgLeadPercentage: 8.0,
           bonusPoolPercentage: 18.0,
           mrnPercentage: 15.0,
-          contracterPercentage: 5.0
+          contracterPercentage: 5.0,
         },
         trainingLinks: [
-          'https://weightlessfinancial.com/training/debt-resolution'
+          "https://weightlessfinancial.com/training/debt-resolution",
         ],
-        orgId: 'ORG-WEIGHTLESS-004',
-        webhookApiKeyHash: 'test-webhook-hash-weightless',
+        orgId: "ORG-WEIGHTLESS-004",
+        webhookApiKeyHash: "test-webhook-hash-weightless",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'Summit Retirement Plans',
-        contactEmail: 'admin@summitretirement.com',
-        website: 'https://summitretirement.com',
-        status: 'ACTIVE',
-        description: '401k, retirement plans, and employee benefits specialist',
+        companyName: "Summit Retirement Plans",
+        contactEmail: "admin@summitretirement.com",
+        website: "https://summitretirement.com",
+        status: "ACTIVE",
+        description: "401k, retirement plans, and employee benefits specialist",
         compensation: {
           agentPercentage: 52.0,
           teamLeadPercentage: 12.0,
           orgLeadPercentage: 6.0,
           bonusPoolPercentage: 25.0,
           mrnPercentage: 20.0,
-          contracterPercentage: 5.0
+          contracterPercentage: 5.0,
         },
         trainingLinks: [
-          'https://summitretirement.com/training/401k-basics',
-          'https://summitretirement.com/training/employee-benefits'
+          "https://summitretirement.com/training/401k-basics",
+          "https://summitretirement.com/training/employee-benefits",
         ],
-        orgId: 'ORG-SUMMIT-005',
-        webhookApiKeyHash: 'test-webhook-hash-summit',
+        orgId: "ORG-SUMMIT-005",
+        webhookApiKeyHash: "test-webhook-hash-summit",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'Wellness for the Workforce',
-        contactEmail: 'contact@wellnessfortheworkforce.com',
-        website: 'https://wellnessfortheworkforce.com',
-        status: 'ACTIVE',
-        description: 'Healthcare, wellness programs, and employee benefits solutions',
+        companyName: "Wellness for the Workforce",
+        contactEmail: "contact@wellnessfortheworkforce.com",
+        website: "https://wellnessfortheworkforce.com",
+        status: "ACTIVE",
+        description:
+          "Healthcare, wellness programs, and employee benefits solutions",
         compensation: {
           agentPercentage: 40.0,
           teamLeadPercentage: 10.0,
           orgLeadPercentage: 7.0,
           bonusPoolPercentage: 20.0,
           mrnPercentage: 18.0,
-          contracterPercentage: 5.0
+          contracterPercentage: 5.0,
         },
         trainingLinks: [],
-        orgId: 'ORG-WELLNESS-006',
-        webhookApiKeyHash: 'test-webhook-hash-wellness',
+        orgId: "ORG-WELLNESS-006",
+        webhookApiKeyHash: "test-webhook-hash-wellness",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyName: 'Impact Health Sharing',
-        contactEmail: 'info@impacthealthsharing.com',
-        website: 'https://www.impacthealthsharing.com',
-        status: 'ACTIVE',
-        description: 'Health sharing and healthcare alternative solutions for medical cost sharing',
+        companyName: "Impact Health Sharing",
+        contactEmail: "info@impacthealthsharing.com",
+        website: "https://www.impacthealthsharing.com",
+        status: "ACTIVE",
+        description:
+          "Health sharing and healthcare alternative solutions for medical cost sharing",
         compensation: {
           agentPercentage: 45.0,
           teamLeadPercentage: 8.0,
           orgLeadPercentage: 5.0,
           bonusPoolPercentage: 22.0,
           mrnPercentage: 15.0,
-          contracterPercentage: 5.0
+          contracterPercentage: 5.0,
         },
         trainingLinks: [
-          'https://www.impacthealthsharing.com/training/health-sharing-basics',
-          'https://www.impacthealthsharing.com/training/medical-cost-sharing'
+          "https://www.impacthealthsharing.com/training/health-sharing-basics",
+          "https://www.impacthealthsharing.com/training/medical-cost-sharing",
         ],
-        orgId: 'ORG-IMPACT-007',
-        webhookApiKeyHash: 'test-webhook-hash-impact',
+        orgId: "ORG-IMPACT-007",
+        webhookApiKeyHash: "test-webhook-hash-impact",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }
+        updatedAt: new Date().toISOString(),
+      },
     ];
 
-    console.log('📊 Creating companies...');
+    console.log("📊 Creating companies...");
     const createdCompanies = [];
     for (const companyData of companies) {
       const { data: company } = await client.models.Company.create(companyData);
@@ -184,68 +188,68 @@ export async function seedData() {
     // We'll let DynamoDB auto-generate IDs and then update referrals with the actual IDs
     const users = [
       {
-        name: 'John Admin',
-        email: 'admin@test.com',
-        phone: '+1234567890',
-        address: '123 Admin Street, Admin City, AC 12345',
-        teamId: 'TEAM-ADMIN-001',
+        name: "John Admin",
+        email: "admin@test.com",
+        phone: "+1234567890",
+        address: "123 Admin Street, Admin City, AC 12345",
+        teamId: "TEAM-ADMIN-001",
         teamLead: false,
         teamLeadId: null,
         orgLeadId: null,
-        companyId: createdCompanies[0]?.id || 'default-company-id',
+        companyId: createdCompanies[0]?.id || "default-company-id",
         bankInfoDocument: null,
         taxDocument: null,
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        name: 'Jane Agent',
-        email: 'agent@test.com',
-        phone: '+1234567891',
-        address: '456 Agent Avenue, Agent City, AC 12346',
-        teamId: 'TEAM-SALES-001',
+        name: "Jane Agent",
+        email: "agent@test.com",
+        phone: "+1234567891",
+        address: "456 Agent Avenue, Agent City, AC 12346",
+        teamId: "TEAM-SALES-001",
         teamLead: false,
         teamLeadId: null,
         orgLeadId: null,
-        companyId: createdCompanies[0]?.id || 'default-company-id',
+        companyId: createdCompanies[0]?.id || "default-company-id",
         bankInfoDocument: null,
         taxDocument: null,
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        name: 'Mike TeamLead',
-        email: 'teamlead@test.com',
-        phone: '+1234567892',
-        address: '789 Lead Lane, Lead City, LC 12347',
-        teamId: 'TEAM-SALES-001',
+        name: "Mike TeamLead",
+        email: "teamlead@test.com",
+        phone: "+1234567892",
+        address: "789 Lead Lane, Lead City, LC 12347",
+        teamId: "TEAM-SALES-001",
         teamLead: true,
         teamLeadId: null,
         orgLeadId: null,
-        companyId: createdCompanies[0]?.id || 'default-company-id',
+        companyId: createdCompanies[0]?.id || "default-company-id",
         bankInfoDocument: null,
         taxDocument: null,
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        name: 'Sarah OrgLead',
-        email: 'orglead@test.com',
-        phone: '+1234567893',
-        address: '321 Organization Blvd, Org City, OC 12348',
-        teamId: 'TEAM-LEADERSHIP-001',
+        name: "Sarah OrgLead",
+        email: "orglead@test.com",
+        phone: "+1234567893",
+        address: "321 Organization Blvd, Org City, OC 12348",
+        teamId: "TEAM-LEADERSHIP-001",
         teamLead: true,
         teamLeadId: null,
         orgLeadId: null,
-        companyId: createdCompanies[0]?.id || 'default-company-id',
+        companyId: createdCompanies[0]?.id || "default-company-id",
         bankInfoDocument: null,
         taxDocument: null,
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }
+        updatedAt: new Date().toISOString(),
+      },
     ];
 
-    console.log('👥 Creating users...');
+    console.log("👥 Creating users...");
     const createdUsers = [];
     for (const userData of users) {
       const { data: user } = await client.models.User.create(userData);
@@ -255,139 +259,277 @@ export async function seedData() {
       }
     }
 
+    // Training resources for each company
+    const trainingResources = [
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        title: "Getting Started Guide",
+        type: "document" as const,
+        url: "https://sunnyhillfinancial.com/training/start",
+        duration: "10 min",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        title: "Intro Video",
+        type: "video" as const,
+        url: "https://sunnyhillfinancial.com/training/intro",
+        duration: "5:30",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[1]?.id || "default-company-id",
+        title: "Business Formation Basics",
+        type: "document" as const,
+        url: "https://www.primecorporateservices.com/training/business-basics",
+        duration: "8 min",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[1]?.id || "default-company-id",
+        title: "Prime Services Overview",
+        type: "video" as const,
+        url: "https://www.primecorporateservices.com/training/overview",
+        duration: "6:00",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    console.log("🎬 Creating training resources...");
+    for (const res of trainingResources) {
+      await client.models.TrainingResource.create(res);
+    }
+
+    // FAQ items for companies
+    const faqItems = [
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        question: "What services does Sunny Hill provide?",
+        answer:
+          "Sunny Hill Financial offers comprehensive planning, investment, and retirement services.",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[1]?.id || "default-company-id",
+        question: "How are Prime Corporate Services commissions paid?",
+        answer:
+          "Commissions are calculated on each service package and paid monthly through MRN.",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    console.log("❓ Creating FAQ items...");
+    for (const faq of faqItems) {
+      await client.models.FaqItem.create(faq);
+    }
+
     // Create sample referrals across different companies
     const referrals = [
       {
-        companyId: createdCompanies[0]?.id || 'default-company-id', // Sunny Hill Financial
-        name: 'Robert Johnson',
-        email: 'robert.johnson@email.com',
-        phoneNumber: '+1555123456',
+        companyId: createdCompanies[0]?.id || "default-company-id", // Sunny Hill Financial
+        name: "Robert Johnson",
+        email: "robert.johnson@email.com",
+        phoneNumber: "+1555123456",
         approximateValue: 85000.0,
-        userId: createdUsers.find(u => u.email === 'agent@test.com')?.id || 'fallback-agent-id',
-        status: 'IN_PROGRESS' as const,
-        notes: 'Interested in comprehensive retirement planning and investment portfolio management',
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_PROGRESS" as const,
+        notes:
+          "Interested in comprehensive retirement planning and investment portfolio management",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[1]?.id || 'default-company-id', // Prime Corporate Services
-        name: 'Emily Davis',
-        email: 'emily.davis@email.com',
-        phoneNumber: '+1555123457',
+        companyId: createdCompanies[1]?.id || "default-company-id", // Prime Corporate Services
+        name: "Emily Davis",
+        email: "emily.davis@email.com",
+        phoneNumber: "+1555123457",
         approximateValue: 45000.0,
-        userId: createdUsers.find(u => u.email === 'agent@test.com')?.id || 'fallback-agent-id',
-        status: 'IN_REVIEW' as const,
-        notes: 'Small business owner looking for tax preparation and bookkeeping services',
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_REVIEW" as const,
+        notes:
+          "Small business owner looking for tax preparation and bookkeeping services",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[2]?.id || 'default-company-id', // ANCO Insurance
-        name: 'Michael Brown',
-        email: 'michael.brown@email.com',
-        phoneNumber: '+1555123458',
+        companyId: createdCompanies[2]?.id || "default-company-id", // ANCO Insurance
+        name: "Michael Brown",
+        email: "michael.brown@email.com",
+        phoneNumber: "+1555123458",
         approximateValue: 125000.0,
-        userId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        status: 'PAID' as const,
-        notes: 'Large corporation needing comprehensive employee benefits package',
+        userId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        status: "PAID" as const,
+        notes:
+          "Large corporation needing comprehensive employee benefits package",
         amount: 6000.0,
-        type: 'COMMISSION' as const,
-        paymentType: 'COMMISSION' as const,
-        paymentStatus: 'PROCESSED' as const,
-        period: '2024-01',
+        type: "COMMISSION" as const,
+        paymentType: "COMMISSION" as const,
+        paymentStatus: "PROCESSED" as const,
+        period: "2024-01",
         processedAt: new Date().toISOString(),
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[3]?.id || 'default-company-id', // Weightless Financial
-        name: 'Sarah Wilson',
-        email: 'sarah.wilson@email.com',
-        phoneNumber: '+1555123459',
+        companyId: createdCompanies[3]?.id || "default-company-id", // Weightless Financial
+        name: "Sarah Wilson",
+        email: "sarah.wilson@email.com",
+        phoneNumber: "+1555123459",
         approximateValue: 15000.0,
-        userId: createdUsers.find(u => u.email === 'agent@test.com')?.id || 'fallback-agent-id',
-        status: 'IN_PROGRESS' as const,
-        notes: 'Needs debt consolidation and credit repair services',
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_PROGRESS" as const,
+        notes: "Needs debt consolidation and credit repair services",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[4]?.id || 'default-company-id', // Summit Retirement Plans
-        name: 'David Martinez',
-        email: 'david.martinez@email.com',
-        phoneNumber: '+1555123460',
+        companyId: createdCompanies[4]?.id || "default-company-id", // Summit Retirement Plans
+        name: "David Martinez",
+        email: "david.martinez@email.com",
+        phoneNumber: "+1555123460",
         approximateValue: 200000.0,
-        userId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        status: 'PAID' as const,
-        notes: 'Mid-size company implementing new 401k plan for 150 employees',
+        userId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        status: "PAID" as const,
+        notes: "Mid-size company implementing new 401k plan for 150 employees",
         amount: 10000.0,
-        type: 'COMMISSION' as const,
-        paymentType: 'COMMISSION' as const,
-        paymentStatus: 'PROCESSED' as const,
-        period: '2024-01',
+        type: "COMMISSION" as const,
+        paymentType: "COMMISSION" as const,
+        paymentStatus: "PROCESSED" as const,
+        period: "2024-01",
         processedAt: new Date().toISOString(),
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[6]?.id || 'default-company-id', // Impact Health Sharing
-        name: 'Jennifer Lee',
-        email: 'jennifer.lee@email.com',
-        phoneNumber: '+1555123461',
+        companyId: createdCompanies[6]?.id || "default-company-id", // Impact Health Sharing
+        name: "Jennifer Lee",
+        email: "jennifer.lee@email.com",
+        phoneNumber: "+1555123461",
         approximateValue: 35000.0,
-        userId: createdUsers.find(u => u.email === 'agent@test.com')?.id || 'fallback-agent-id',
-        status: 'IN_REVIEW' as const,
-        notes: 'Family of 4 interested in health sharing plan as alternative to traditional insurance',
-        teamLeadId: createdUsers.find(u => u.email === 'teamlead@test.com')?.id || 'fallback-teamlead-id',
-        orgLeadId: createdUsers.find(u => u.email === 'orglead@test.com')?.id || 'fallback-orglead-id',
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_REVIEW" as const,
+        notes:
+          "Family of 4 interested in health sharing plan as alternative to traditional insurance",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }
+        updatedAt: new Date().toISOString(),
+      },
     ];
 
-    console.log('📋 Creating referrals...');
+    console.log("📋 Creating referrals...");
     for (const referralData of referrals) {
-      const { data: referral } = await client.models.Referral.create(referralData);
+      const { data: referral } =
+        await client.models.Referral.create(referralData);
       if (referral) {
-        console.log(`✅ Created referral: ${referral.name} - ${referral.status}`);
+        console.log(
+          `✅ Created referral: ${referral.name} - ${referral.status}`,
+        );
       }
     }
 
-    console.log('\n🎉 Seed data creation completed successfully!');
-    console.log('\n📊 Companies Created:');
+    console.log("\n🎉 Seed data creation completed successfully!");
+    console.log("\n📊 Companies Created:");
     createdCompanies.forEach((company, index) => {
       console.log(`${index + 1}. ${company.companyName} (ID: ${company.id})`);
     });
-    
-    console.log('\n📝 Test Accounts Created:');
-    console.log('┌─────────────────────────────────────────────────────────────┐');
-    console.log('│ NOTE: You need to create these Cognito users manually:     │');
-    console.log('├─────────────────────────────────────────────────────────────┤');
-    console.log('│ Email: admin@test.com     | Role: Admin                     │');
-    console.log('│ Email: agent@test.com     | Role: Agent                     │');
-    console.log('│ Email: teamlead@test.com  | Role: Team Lead                 │');
-    console.log('│ Email: orglead@test.com   | Role: Organization Lead         │');
-    console.log('├─────────────────────────────────────────────────────────────┤');
-    console.log('│ Password: TempPass123!    | (for all test accounts)        │');
-    console.log(`│ Primary Company: ${createdCompanies[0]?.companyName || 'Sunny Hill Financial'}                    │`);
-    console.log('│ Company ID: ' + (createdCompanies[0]?.id || 'See output above').padEnd(43) + '│');
-    console.log('└─────────────────────────────────────────────────────────────┘');
 
+    console.log("\n📝 Test Accounts Created:");
+    console.log(
+      "┌─────────────────────────────────────────────────────────────┐",
+    );
+    console.log(
+      "│ NOTE: You need to create these Cognito users manually:     │",
+    );
+    console.log(
+      "├─────────────────────────────────────────────────────────────┤",
+    );
+    console.log(
+      "│ Email: admin@test.com     | Role: Admin                     │",
+    );
+    console.log(
+      "│ Email: agent@test.com     | Role: Agent                     │",
+    );
+    console.log(
+      "│ Email: teamlead@test.com  | Role: Team Lead                 │",
+    );
+    console.log(
+      "│ Email: orglead@test.com   | Role: Organization Lead         │",
+    );
+    console.log(
+      "├─────────────────────────────────────────────────────────────┤",
+    );
+    console.log(
+      "│ Password: TempPass123!    | (for all test accounts)        │",
+    );
+    console.log(
+      `│ Primary Company: ${createdCompanies[0]?.companyName || "Sunny Hill Financial"}                    │`,
+    );
+    console.log(
+      "│ Company ID: " +
+        (createdCompanies[0]?.id || "See output above").padEnd(43) +
+        "│",
+    );
+    console.log(
+      "└─────────────────────────────────────────────────────────────┘",
+    );
   } catch (error) {
-    console.error('❌ Error seeding data:', error);
+    console.error("❌ Error seeding data:", error);
     throw error;
   }
 }
 
 // Export for use in other files
-export default seedData; 
+export default seedData;

--- a/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
@@ -1,22 +1,22 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { 
-  ArrowLeft, 
-  ExternalLink, 
-  FileText, 
-  Video, 
-  Send, 
-  CircleDollarSign, 
-  BadgePercent, 
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  ExternalLink,
+  FileText,
+  Video,
+  Send,
+  CircleDollarSign,
+  BadgePercent,
   CreditCard,
-  Link2
-} from 'lucide-react';
-import { Button } from '../../components/ui/Button';
-import { toast } from '../../components/ui/Toaster';
-import StatsOverview, { StatItem } from '../../components/StatsOverview';
-import { generateClient } from 'aws-amplify/data';
-import type { Schema } from '../../amplify/data/resource';
-import { companyMeta } from '../../data/companyMeta';
+  Link2,
+} from "lucide-react";
+import { Button } from "../../components/ui/Button";
+import { toast } from "../../components/ui/Toaster";
+import StatsOverview, { StatItem } from "../../components/StatsOverview";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "../../amplify/data/resource";
+import { companyMeta } from "../../data/companyMeta";
 
 const client = generateClient<Schema>();
 
@@ -24,8 +24,14 @@ const CompanyDetailPage = () => {
   const { companyId } = useParams<{ companyId: string }>();
   const navigate = useNavigate();
 
-  const [company, setCompany] = useState<Schema['Company']['type'] | null>(null);
+  const [company, setCompany] = useState<Schema["Company"]["type"] | null>(
+    null,
+  );
   const [stats, setStats] = useState<StatItem[]>([]);
+  const [trainingResources, setTrainingResources] = useState<
+    Schema["TrainingResource"]["type"][]
+  >([]);
+  const [faqItems, setFaqItems] = useState<Schema["FaqItem"]["type"][]>([]);
 
   useEffect(() => {
     const loadCompany = async () => {
@@ -34,8 +40,8 @@ const CompanyDetailPage = () => {
         const { data } = await client.models.Company.get({ id: companyId });
         setCompany(data);
       } catch (err) {
-        console.error('Failed to load company', err);
-        navigate('/dashboard/learn');
+        console.error("Failed to load company", err);
+        navigate("/dashboard/learn");
       }
     };
     loadCompany();
@@ -51,128 +57,106 @@ const CompanyDetailPage = () => {
 
         const totalEarnings = data.reduce((s, r) => s + (r.amount ?? 0), 0);
         const pendingCommissions = data
-          .filter((r) => r.paymentStatus === 'PENDING')
+          .filter((r) => r.paymentStatus === "PENDING")
           .reduce((s, r) => s + (r.amount ?? 0), 0);
         const referralsCount = data.length;
         const successfulReferrals = data.filter(
-          (r) => r.paymentStatus === 'PROCESSED'
+          (r) => r.paymentStatus === "PROCESSED",
         ).length;
 
         const computed: StatItem[] = [
           {
-            label: 'Total Earnings',
+            label: "Total Earnings",
             value: `$${totalEarnings.toLocaleString()}`,
-            icon: 'DollarSign',
-            bgColor: 'bg-blue-100',
-            iconColor: 'text-primary',
+            icon: "DollarSign",
+            bgColor: "bg-blue-100",
+            iconColor: "text-primary",
           },
           {
-            label: 'Pending Commissions',
+            label: "Pending Commissions",
             value: `$${pendingCommissions.toLocaleString()}`,
-            icon: 'Clock',
-            bgColor: 'bg-green-100',
-            iconColor: 'text-success',
+            icon: "Clock",
+            bgColor: "bg-green-100",
+            iconColor: "text-success",
           },
           {
-            label: 'Total Referrals',
+            label: "Total Referrals",
             value: referralsCount.toString(),
-            icon: 'Users',
-            bgColor: 'bg-purple-100',
-            iconColor: 'text-purple-600',
+            icon: "Users",
+            bgColor: "bg-purple-100",
+            iconColor: "text-purple-600",
           },
           {
-            label: 'Success Rate',
+            label: "Success Rate",
             value: referralsCount
               ? `${Math.round((successfulReferrals / referralsCount) * 100)}%`
-              : '0%',
-            icon: 'TrendingUp',
-            bgColor: 'bg-orange-100',
-            iconColor: 'text-orange-600',
+              : "0%",
+            icon: "TrendingUp",
+            bgColor: "bg-orange-100",
+            iconColor: "text-orange-600",
           },
         ];
         setStats(computed);
       } catch (err) {
-        console.error('Failed to load stats', err);
+        console.error("Failed to load stats", err);
       }
     };
     loadStats();
   }, [companyId]);
 
+  useEffect(() => {
+    const loadTraining = async () => {
+      if (!companyId) return;
+      try {
+        const { data } = await client.models.TrainingResource.list({
+          filter: { companyId: { eq: companyId } },
+        });
+        setTrainingResources(data);
+      } catch (err) {
+        console.error("Failed to load training resources", err);
+      }
+    };
+    loadTraining();
+  }, [companyId]);
+
+  useEffect(() => {
+    const loadFaq = async () => {
+      if (!companyId) return;
+      try {
+        const { data } = await client.models.FaqItem.list({
+          filter: { companyId: { eq: companyId } },
+        });
+        setFaqItems(data);
+      } catch (err) {
+        console.error("Failed to load FAQ items", err);
+      }
+    };
+    loadFaq();
+  }, [companyId]);
+
   if (!company) {
-    navigate('/dashboard/learn');
+    navigate("/dashboard/learn");
     return null;
   }
-  
-  // Mock training resources
-  const trainingResources = [
-    { 
-      id: 1, 
-      title: 'Getting Started Guide', 
-      type: 'document', 
-      icon: <FileText className="h-4 w-4" />,
-      duration: '10 min read'
-    },
-    { 
-      id: 2, 
-      title: 'Introduction to Services', 
-      type: 'video', 
-      icon: <Video className="h-4 w-4" />,
-      duration: '5:30'
-    },
-    { 
-      id: 3, 
-      title: 'How to Position Services', 
-      type: 'document', 
-      icon: <FileText className="h-4 w-4" />,
-      duration: '15 min read'
-    },
-    { 
-      id: 4, 
-      title: 'Advanced Referral Strategy', 
-      type: 'video', 
-      icon: <Video className="h-4 w-4" />,
-      duration: '12:45'
-    },
-  ];
-  
-  // Mock FAQ items
-  const faqItems = [
-    {
-      question: 'What services does this company provide?',
-      answer: `${company?.name ?? ''} provides ${(companyMeta[companyId || '']?.tags || []).join(', ')} services. ${company?.description ?? ''}`
-    },
-    {
-      question: 'How are commissions calculated?',
-      answer: 'Commissions are calculated based on the specific service purchased by the referred client and are typically paid monthly. Refer to the commission structure above for more details.'
-    },
-    {
-      question: 'How long does it take to process a referral?',
-      answer: 'Most referrals are processed within 1-2 business days. You will receive an email notification when your referral has been received and when it has been contacted.'
-    },
-    {
-      question: 'When are commissions paid out?',
-      answer: 'Commissions are paid on a monthly basis. Any commissions earned during the month will be paid out by the 15th of the following month via direct deposit.'
-    },
-  ];
-  
+
   return (
     <div className="space-y-8">
       {/* Header with back button */}
       <div className="flex items-center space-x-4">
-        <Button 
-          variant="outline" 
-          size="sm" 
-          onClick={() => navigate('/dashboard/learn')}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate("/dashboard/learn")}
           className="flex items-center"
         >
           <ArrowLeft className="mr-1 h-4 w-4" />
           Back
         </Button>
-        
+
         <div>
           <h1 className="text-2xl font-bold text-gray-900">{company?.name}</h1>
           <p className="text-sm text-gray-500">
-            {(companyMeta[companyId || '']?.tags || []).join(' • ')}
+            {(companyMeta[companyId || ""]?.tags || []).join(" • ")}
           </p>
         </div>
       </div>
@@ -185,21 +169,27 @@ const CompanyDetailPage = () => {
           <div className="md:flex-shrink-0 flex items-center justify-center p-8 bg-gray-50 md:w-64">
             <div
               className="w-24 h-24 rounded-full flex items-center justify-center"
-              style={{ backgroundColor: companyMeta[companyId || '']?.bgColor || '#f3f4f6' }}
+              style={{
+                backgroundColor:
+                  companyMeta[companyId || ""]?.bgColor || "#f3f4f6",
+              }}
             >
-              {companyMeta[companyId || '']?.icon &&
-                React.cloneElement(companyMeta[companyId || ''].icon as React.ReactElement, { size: 48 })}
+              {companyMeta[companyId || ""]?.icon &&
+                React.cloneElement(
+                  companyMeta[companyId || ""].icon as React.ReactElement,
+                  { size: 48 },
+                )}
             </div>
           </div>
-          
+
           <div className="p-8 flex-1">
-            <h2 className="text-xl font-semibold text-gray-900">About {company?.name}</h2>
-            <p className="mt-4 text-gray-600">
-              {company?.description}
-            </p>
+            <h2 className="text-xl font-semibold text-gray-900">
+              About {company?.name}
+            </h2>
+            <p className="mt-4 text-gray-600">{company?.description}</p>
 
             <div className="mt-6 flex flex-wrap gap-2">
-              {(companyMeta[companyId || '']?.tags || []).map((tag, index) => (
+              {(companyMeta[companyId || ""]?.tags || []).map((tag, index) => (
                 <span
                   key={index}
                   className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800"
@@ -208,22 +198,25 @@ const CompanyDetailPage = () => {
                 </span>
               ))}
             </div>
-            
+
             <div className="mt-8 flex flex-col sm:flex-row gap-4">
-              <a 
-                href={company?.website || '#'}
-                target="_blank" 
+              <a
+                href={company?.website || "#"}
+                target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block"
               >
-                <Button variant="outline" className="w-full sm:w-auto flex items-center">
+                <Button
+                  variant="outline"
+                  className="w-full sm:w-auto flex items-center"
+                >
                   <ExternalLink className="mr-2 h-4 w-4" />
                   Visit Website
                 </Button>
               </a>
-              
+
               <a
-                href={companyMeta[companyId || '']?.referralUrl}
+                href={companyMeta[companyId || ""]?.referralUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block"
@@ -237,11 +230,13 @@ const CompanyDetailPage = () => {
           </div>
         </div>
       </div>
-      
+
       {/* Commission information */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-8">
-        <h2 className="text-xl font-semibold text-gray-900 mb-6">Commission Structure</h2>
-        
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">
+          Commission Structure
+        </h2>
+
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="bg-gray-50 p-6 rounded-lg">
             <div className="flex items-center mb-4">
@@ -249,26 +244,25 @@ const CompanyDetailPage = () => {
               <h3 className="text-lg font-medium">Commission Rate</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {companyMeta[companyId || '']?.commissionInfo?.rate || '15-20%'}
+              {companyMeta[companyId || ""]?.commissionInfo?.rate || "15-20%"}
             </p>
-            <p className="mt-2 text-sm text-gray-500">
-              Of the service value
-            </p>
+            <p className="mt-2 text-sm text-gray-500">Of the service value</p>
           </div>
-          
+
           <div className="bg-gray-50 p-6 rounded-lg">
             <div className="flex items-center mb-4">
               <CircleDollarSign className="h-6 w-6 text-success mr-2" />
               <h3 className="text-lg font-medium">Average Payout</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {companyMeta[companyId || '']?.commissionInfo?.average || '$500-$1,200'}
+              {companyMeta[companyId || ""]?.commissionInfo?.average ||
+                "$500-$1,200"}
             </p>
             <p className="mt-2 text-sm text-gray-500">
               Per successful referral
             </p>
           </div>
-          
+
           <div className="bg-gray-50 p-6 rounded-lg">
             <div className="flex items-center mb-4">
               <CreditCard className="h-6 w-6 text-purple-600 mr-2" />
@@ -280,14 +274,19 @@ const CompanyDetailPage = () => {
             </p>
           </div>
         </div>
-        
+
         <div className="mt-8 flex justify-center">
-          <Button 
+          <Button
             variant="outline"
             className="flex items-center"
             onClick={() => {
-              navigator.clipboard.writeText(`${window.location.origin}/r/${companyId}`);
-              toast.success("Referral link copied!", "You can now share this with your clients.");
+              navigator.clipboard.writeText(
+                `${window.location.origin}/r/${companyId}`,
+              );
+              toast.success(
+                "Referral link copied!",
+                "You can now share this with your clients.",
+              );
             }}
           >
             <Link2 className="mr-2 h-4 w-4" />
@@ -295,53 +294,76 @@ const CompanyDetailPage = () => {
           </Button>
         </div>
       </div>
-      
+
       {/* Training resources */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-8">
-        <h2 className="text-xl font-semibold text-gray-900 mb-6">Training Resources</h2>
-        
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">
+          Training Resources
+        </h2>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {trainingResources.map((resource) => (
-            <div 
-              key={resource.id} 
-              className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-primary/50 transition-colors"
-            >
-              <div className="flex-shrink-0">
-                <div 
-                  className={`w-10 h-10 rounded-full flex items-center justify-center ${
-                    resource.type === 'video' ? 'bg-red-100' : 'bg-blue-100'
-                  }`}
-                >
-                  {resource.icon}
+          {trainingResources.map((resource) => {
+            const icon =
+              resource.type === "video" ? (
+                <Video className="h-4 w-4" />
+              ) : (
+                <FileText className="h-4 w-4" />
+              );
+            return (
+              <div
+                key={resource.id}
+                className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-primary/50 transition-colors"
+              >
+                <div className="flex-shrink-0">
+                  <div
+                    className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                      resource.type === "video" ? "bg-red-100" : "bg-blue-100"
+                    }`}
+                  >
+                    {icon}
+                  </div>
+                </div>
+
+                <div className="ml-4 flex-1">
+                  <h3 className="text-sm font-medium text-gray-900">
+                    {resource.title}
+                  </h3>
+                  <p className="text-xs text-gray-500">
+                    {resource.type === "video" ? "Video" : "Document"} •{" "}
+                    {resource.duration}
+                  </p>
+                </div>
+
+                <div>
+                  <Button variant="ghost" size="sm" asChild>
+                    <a
+                      href={resource.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  </Button>
                 </div>
               </div>
-              
-              <div className="ml-4 flex-1">
-                <h3 className="text-sm font-medium text-gray-900">{resource.title}</h3>
-                <p className="text-xs text-gray-500">
-                  {resource.type === 'video' ? 'Video' : 'Document'} • {resource.duration}
-                </p>
-              </div>
-              
-              <div>
-                <Button variant="ghost" size="sm">
-                  <ExternalLink className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
-      
+
       {/* FAQs */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-8">
-        <h2 className="text-xl font-semibold text-gray-900 mb-6">Frequently Asked Questions</h2>
-        
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">
+          Frequently Asked Questions
+        </h2>
+
         <div className="space-y-6">
           {faqItems.map((item, index) => (
             <div key={index} className="border-b border-gray-200 pb-5">
               <button className="text-left w-full flex justify-between items-start">
-                <h3 className="text-base font-medium text-gray-900">{item.question}</h3>
+                <h3 className="text-base font-medium text-gray-900">
+                  {item.question}
+                </h3>
                 {/* We could add an expand/collapse button here if needed */}
               </button>
               <div className="mt-2">
@@ -351,24 +373,29 @@ const CompanyDetailPage = () => {
           ))}
         </div>
       </div>
-      
+
       {/* CTA */}
       <div className="bg-primary rounded-lg shadow-md overflow-hidden">
         <div className="px-6 py-8 md:p-8 md:flex md:items-center md:justify-between">
           <div className="text-center md:text-left">
-            <h2 className="text-xl font-bold text-white">Ready to start referring?</h2>
+            <h2 className="text-xl font-bold text-white">
+              Ready to start referring?
+            </h2>
             <p className="mt-1 text-primary-foreground text-opacity-90">
               Start earning commissions by referring clients to {company?.name}.
             </p>
           </div>
           <div className="mt-6 md:mt-0">
-            <a 
-              href={companyMeta[companyId || '']?.referralUrl}
-              target="_blank" 
+            <a
+              href={companyMeta[companyId || ""]?.referralUrl}
+              target="_blank"
               rel="noopener noreferrer"
               className="inline-block"
             >
-              <Button variant="outline" className="w-full md:w-auto bg-white text-primary hover:bg-gray-100">
+              <Button
+                variant="outline"
+                className="w-full md:w-auto bg-white text-primary hover:bg-gray-100"
+              >
                 Make a Referral Now
               </Button>
             </a>


### PR DESCRIPTION
## Summary
- add TrainingResource and FaqItem models
- seed training and faq data for strategic partners
- fetch training resources and FAQs in partner detail page

## Testing
- `pnpm frontend:lint` *(fails: 4 errors)*
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684b8e1fbf288332aa8347277c665061