### PR TITLE
Fetch business dashboard data from API

### DIFF
--- a/apps/frontend-app/amplify/data/seed.ts
+++ b/apps/frontend-app/amplify/data/seed.ts
@@ -353,7 +353,7 @@ export async function seedData() {
         updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[1]?.id || "default-company-id", // Prime Corporate Services
+        companyId: createdCompanies[0]?.id || "default-company-id",
         name: "Emily Davis",
         email: "emily.davis@email.com",
         phoneNumber: "+1555123457",
@@ -374,7 +374,7 @@ export async function seedData() {
         updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[2]?.id || "default-company-id", // ANCO Insurance
+        companyId: createdCompanies[0]?.id || "default-company-id",
         name: "Michael Brown",
         email: "michael.brown@email.com",
         phoneNumber: "+1555123458",
@@ -401,7 +401,7 @@ export async function seedData() {
         updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[3]?.id || "default-company-id", // Weightless Financial
+        companyId: createdCompanies[0]?.id || "default-company-id",
         name: "Sarah Wilson",
         email: "sarah.wilson@email.com",
         phoneNumber: "+1555123459",
@@ -421,7 +421,7 @@ export async function seedData() {
         updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[4]?.id || "default-company-id", // Summit Retirement Plans
+        companyId: createdCompanies[0]?.id || "default-company-id",
         name: "David Martinez",
         email: "david.martinez@email.com",
         phoneNumber: "+1555123460",
@@ -447,7 +447,7 @@ export async function seedData() {
         updatedAt: new Date().toISOString(),
       },
       {
-        companyId: createdCompanies[6]?.id || "default-company-id", // Impact Health Sharing
+        companyId: createdCompanies[0]?.id || "default-company-id",
         name: "Jennifer Lee",
         email: "jennifer.lee@email.com",
         phoneNumber: "+1555123461",
@@ -458,6 +458,66 @@ export async function seedData() {
         status: "IN_REVIEW" as const,
         notes:
           "Family of 4 interested in health sharing plan as alternative to traditional insurance",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        name: "John Smith",
+        email: "john.smith@email.com",
+        phoneNumber: "+1555123462",
+        approximateValue: 0,
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_PROGRESS" as const,
+        notes: "Interested in business services",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        name: "Sarah Johnson",
+        email: "sarah.johnson@email.com",
+        phoneNumber: "+1555123463",
+        approximateValue: 0,
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_PROGRESS" as const,
+        notes: "Looking for financial planning services",
+        teamLeadId:
+          createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
+          "fallback-teamlead-id",
+        orgLeadId:
+          createdUsers.find((u) => u.email === "orglead@test.com")?.id ||
+          "fallback-orglead-id",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        companyId: createdCompanies[0]?.id || "default-company-id",
+        name: "Michael Brown",
+        email: "michael.brown2@email.com",
+        phoneNumber: "+1555123464",
+        approximateValue: 0,
+        userId:
+          createdUsers.find((u) => u.email === "agent@test.com")?.id ||
+          "fallback-agent-id",
+        status: "IN_REVIEW" as const,
+        notes: "Follow up about health sharing options",
         teamLeadId:
           createdUsers.find((u) => u.email === "teamlead@test.com")?.id ||
           "fallback-teamlead-id",

--- a/apps/frontend-app/scripts/seed.ts
+++ b/apps/frontend-app/scripts/seed.ts
@@ -31,9 +31,9 @@ async function runSeed() {
       const outputs = JSON.parse(fs.readFileSync(outputsPath, 'utf8'));
       Amplify.configure(outputs);
       console.log('✅ Amplify configured successfully');
-    } catch (error) {
-      console.error('❌ Failed to load amplify_outputs.json. Make sure you have deployed your app first.');
-      console.error('Run: npx ampx sandbox or npx ampx deploy');
+  } catch {
+    console.error('❌ Failed to load amplify_outputs.json. Make sure you have deployed your app first.');
+    console.error('Run: npx ampx sandbox or npx ampx deploy');
       process.exit(1);
     }
     

--- a/apps/frontend-app/src/components/PendingReferralsCard.tsx
+++ b/apps/frontend-app/src/components/PendingReferralsCard.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Button } from './ui/Button';
 
 export type PendingReferral = {
-  id: number;
+  id: string | number;
   date: string;
   client: string;
   company: string;
   status: string;
-  estimatedCommission: number;
+  estimatedCommission?: number | null;
 };
 
 interface PendingReferralsCardProps {

--- a/apps/frontend-app/src/components/RecentPaymentsCard.tsx
+++ b/apps/frontend-app/src/components/RecentPaymentsCard.tsx
@@ -3,7 +3,7 @@ import { CreditCard } from 'lucide-react';
 import { Button } from './ui/Button';
 
 export type RecentPayment = {
-  id: number;
+  id: string | number;
   date: string;
   amount: number;
   status: string;
@@ -15,7 +15,7 @@ interface RecentPaymentsCardProps {
   payments: RecentPayment[];
   onViewHistory?: () => void;
   showStatusToggle?: boolean;
-  onToggleStatus?: (id: number) => void;
+  onToggleStatus?: (id: string | number) => void;
 }
 
 const RecentPaymentsCard: React.FC<RecentPaymentsCardProps> = ({

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 // Icons are referenced by name via an icon map; avoid importing unused icons
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
@@ -6,27 +6,98 @@ import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';
 import PendingReferralsCard, { PendingReferral } from '../../components/PendingReferralsCard';
 import RecentPaymentsCard, { RecentPayment } from '../../components/RecentPaymentsCard';
 import StatsOverview, { StatItem } from '../../components/StatsOverview';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../../amplify/data/resource';
+import { useAuth } from '../../contexts/AuthContext';
+
+const client = generateClient<Schema>();
 
 const BusinessPage = () => {
-  
-  // Mock data for demonstration
-  const totalEarnings = 14250.75;
-  const pendingCommissions = 2430.50;
-  const referralsCount = 35;
-  const successfulReferrals = 28;
-  
-  const recentPayments: RecentPayment[] = [
-    { id: 1, date: '2023-06-15', amount: 1250.50, status: 'Paid', company: 'Sunny Hill Financial' },
-    { id: 2, date: '2023-05-20', amount: 945.25, status: 'Paid', company: 'Prime Corporate Services' },
-    { id: 3, date: '2023-04-10', amount: 1750.00, status: 'Paid', company: 'ANCO Insurance' },
-    { id: 4, date: '2023-03-05', amount: 830.00, status: 'Paid', company: 'Summit Business Syndicate' },
-  ];
-  
-  const pendingReferrals: PendingReferral[] = [
-    { id: 1, date: '2023-06-28', client: 'John Smith', company: 'Prime Corporate Services', status: 'In Progress', estimatedCommission: 850.00 },
-    { id: 2, date: '2023-06-25', client: 'Sarah Johnson', company: 'Sunny Hill Financial', status: 'In Progress', estimatedCommission: 1280.50 },
-    { id: 3, date: '2023-06-20', client: 'Michael Brown', company: 'Impact Health Sharing', status: 'In Review', estimatedCommission: 300.00 },
-  ];
+  const { user } = useAuth();
+
+  const [totalEarnings, setTotalEarnings] = useState(0);
+  const [pendingCommissions, setPendingCommissions] = useState(0);
+  const [referralsCount, setReferralsCount] = useState(0);
+  const [successfulReferrals, setSuccessfulReferrals] = useState(0);
+  const [recentPayments, setRecentPayments] = useState<RecentPayment[]>([]);
+  const [pendingReferrals, setPendingReferrals] = useState<PendingReferral[]>([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      if (!user?.id) return;
+
+      try {
+        const { data } = await client.models.Referral.list({
+          filter: { userId: { eq: user.id } },
+        });
+
+        const companies: Record<string, string> = {};
+        const getCompanyName = async (id: string) => {
+          if (!companies[id]) {
+            try {
+              const { data: company } = await client.models.Company.get({ id });
+              companies[id] = company?.companyName || id;
+            } catch {
+              companies[id] = id;
+            }
+          }
+          return companies[id];
+        };
+
+        let totalEarn = 0;
+        let pendingComm = 0;
+        let successCount = 0;
+
+        const pending: PendingReferral[] = [];
+        const payments: RecentPayment[] = [];
+
+        for (const r of data) {
+          const companyName = await getCompanyName(r.companyId);
+
+          if (r.paymentStatus === 'PROCESSED') {
+            successCount += 1;
+            totalEarn += r.amount ?? 0;
+            payments.push({
+              id: r.id,
+              date: r.processedAt || r.createdAt || '',
+              amount: r.amount || 0,
+              status: 'Paid',
+              company: companyName,
+            });
+          }
+
+          if (
+            r.paymentStatus === 'PENDING' ||
+            r.status === 'IN_PROGRESS' ||
+            r.status === 'IN_REVIEW'
+          ) {
+            pendingComm += r.amount ?? 0;
+            pending.push({
+              id: r.id,
+              date: r.createdAt || '',
+              client: r.name,
+              company: companyName,
+              status: r.status?.replace('_', ' ') || 'In Progress',
+              estimatedCommission: r.amount ?? null,
+            });
+          }
+        }
+
+        payments.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+        setTotalEarnings(totalEarn);
+        setPendingCommissions(pendingComm);
+        setReferralsCount(data.length);
+        setSuccessfulReferrals(successCount);
+        setRecentPayments(payments.slice(0, 4));
+        setPendingReferrals(pending.slice(0, 3));
+      } catch (error) {
+        console.error('Failed to load business data', error);
+      }
+    };
+
+    loadData();
+  }, [user]);
 
   const earningsData6Months: EarningsPoint[] = [
     { month: 'Jan', earnings: 2000 },


### PR DESCRIPTION
## Summary
- expand data types for dashboard cards
- load pending referrals and recent payments from the database in the business dashboard
- fix linter issues in SiteAdmin page and seed script
- update seed script so all referrals belong to Sunny Hill Financial and include extra sample referrals

## Testing
- `pnpm -C apps/frontend-app run lint`
- `pnpm -C apps/frontend-app run test`


------
https://chatgpt.com/codex/tasks/task_b_684b99cd5d6483328044773d8e53dd81