### PR TITLE
Fix referral webhook auth

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -35,6 +35,7 @@ export const schema = a.schema({
       allow.guest().to(["read"]),
       allow.group("admin").to(["create", "read", "update", "delete"]),
       allow.group("companyAdmin").to(["read", "update"]),
+      allow.iam().to(["read"]),
       // Allow API key for seed scripts
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),
@@ -111,6 +112,7 @@ export const schema = a.schema({
       allow.group("admin").to(["create", "read", "update", "delete"]),
       allow.group("teamLead").to(["update", "read"]),
       allow.group("orgLead").to(["update", "read"]),
+      allow.iam().to(["read", "update"]),
       // Allow API key for seed scripts
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),

--- a/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
+++ b/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
@@ -141,7 +141,16 @@ export const handler = async (event: APIGatewayEvent): Promise<APIGatewayRespons
       };
     }
 
-    await client.models.Referral.update({ id: referralId, status });
+    const updateInput: Partial<Schema['Referral']['type']> & { id: string } = {
+      id: referralId,
+      status,
+    };
+
+    if (status === 'PAID') {
+      updateInput.paymentStatus = 'PENDING';
+    }
+
+    await client.models.Referral.update(updateInput);
 
     return { 
       statusCode: 200,


### PR DESCRIPTION
## Summary
- allow `updateReferralStatusWebhook` lambda to read companies and update referrals via IAM
- set `paymentStatus` to `PENDING` when webhook marks referral as `PAID`

## Testing
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684bb1de85f08332aebf35036770efe4