### PR TITLE
Fix Amplify IAM rule

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -35,7 +35,7 @@ export const schema = a.schema({
       allow.guest().to(["read"]),
       allow.group("admin").to(["create", "read", "update", "delete"]),
       allow.group("companyAdmin").to(["read", "update"]),
-      allow.iam().to(["read"]),
+      allow.authenticated("identityPool").to(["read"]),
       // Allow API key for seed scripts
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),
@@ -112,7 +112,7 @@ export const schema = a.schema({
       allow.group("admin").to(["create", "read", "update", "delete"]),
       allow.group("teamLead").to(["update", "read"]),
       allow.group("orgLead").to(["update", "read"]),
-      allow.iam().to(["read", "update"]),
+      allow.authenticated("identityPool").to(["read", "update"]),
       // Allow API key for seed scripts
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),

--- a/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
+++ b/apps/frontend-app/amplify/functions/updateReferralStatusWebhook/handler.ts
@@ -76,9 +76,9 @@ export const handler = async (event: APIGatewayEvent): Promise<APIGatewayRespons
 
   const hash = crypto.createHash('sha256').update(apiKey.trim()).digest('hex');
 
-  // Generate client with IAM authentication for Lambda execution
+  // Generate client using the API key configured for this backend
   const client = generateClient<Schema>({
-    authMode: 'iam'
+    authMode: 'apiKey',
   });
 
   try {

--- a/apps/frontend-app/src/pages/VerifyEmailPage.tsx
+++ b/apps/frontend-app/src/pages/VerifyEmailPage.tsx
@@ -1,21 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { Button } from '../components/ui/Button';
-import { Input } from '../components/ui/Input';
-import { toast } from '../components/ui/Toaster';
-import { confirmSignUp, resendSignUpCode, fetchUserAttributes } from 'aws-amplify/auth';
-import { useAuth } from '../contexts/AuthContext';
-import { generateClient } from 'aws-amplify/data';
-import type { Schema } from '../../amplify/data/resource';
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "../components/ui/Button";
+import { Input } from "../components/ui/Input";
+import { toast } from "../components/ui/Toaster";
+import { confirmSignUp, resendSignUpCode } from "aws-amplify/auth";
+import { useAuth } from "../contexts/AuthContext";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "../../amplify/data/resource";
 
 const client = generateClient<Schema>();
 
 const verifySchema = z.object({
-  email: z.string().email('Please enter a valid email'),
-  code: z.string().min(1, 'Verification code is required'),
+  email: z.string().email("Please enter a valid email"),
+  code: z.string().min(1, "Verification code is required"),
 });
 
 type VerifyForm = z.infer<typeof verifySchema>;
@@ -24,21 +24,26 @@ const VerifyEmailPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { login } = useAuth();
-  const initialEmail = (location.state as { email?: string })?.email || '';
+  const initialEmail = (location.state as { email?: string })?.email || "";
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { register, handleSubmit, formState: { errors }, watch } = useForm<VerifyForm>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<VerifyForm>({
     resolver: zodResolver(verifySchema),
-    defaultValues: { email: initialEmail, code: '' },
+    defaultValues: { email: initialEmail, code: "" },
   });
 
   // Clean up temp data on component unmount (if user navigates away)
   useEffect(() => {
     return () => {
       // Only clean up if user is navigating away without completing verification
-      if (!window.location.pathname.includes('/dashboard')) {
-        sessionStorage.removeItem('tempPassword');
-        sessionStorage.removeItem('pendingUserData');
+      if (!window.location.pathname.includes("/dashboard")) {
+        sessionStorage.removeItem("tempPassword");
+        sessionStorage.removeItem("pendingUserData");
       }
     };
   }, []);
@@ -46,25 +51,28 @@ const VerifyEmailPage: React.FC = () => {
   const onSubmit = async (data: VerifyForm) => {
     setIsSubmitting(true);
     try {
-      await confirmSignUp({ username: data.email, confirmationCode: data.code });
-      
+      await confirmSignUp({
+        username: data.email,
+        confirmationCode: data.code,
+      });
+
       // Get the temporary password stored during registration
-      const tempPassword = sessionStorage.getItem('tempPassword');
-      
+      const tempPassword = sessionStorage.getItem("tempPassword");
+
       if (tempPassword) {
         // Auto-login the user after successful verification
         await login(data.email, tempPassword);
-        
+
         // Save user to DynamoDB after successful login
         try {
           // Get the stored user data from registration
-          const pendingUserDataStr = sessionStorage.getItem('pendingUserData');
-          
+          const pendingUserDataStr = sessionStorage.getItem("pendingUserData");
+
           if (pendingUserDataStr) {
             const pendingUserData = JSON.parse(pendingUserDataStr);
-            const { getCurrentUser } = await import('aws-amplify/auth');
+            const { getCurrentUser } = await import("aws-amplify/auth");
             const currentUser = await getCurrentUser();
-            
+
             // Create user record in DynamoDB using original registration data
             await client.models.User.create({
               id: currentUser.userId, // Cognito user ID
@@ -80,33 +88,35 @@ const VerifyEmailPage: React.FC = () => {
               bankInfoDocument: null,
               taxDocument: null,
               createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString()
+              updatedAt: new Date().toISOString(),
             });
-            
+
             // Clean up the stored data
-            sessionStorage.removeItem('pendingUserData');
-            console.log('User saved to DynamoDB successfully');
+            sessionStorage.removeItem("pendingUserData");
+            console.log("User saved to DynamoDB successfully");
           } else {
-            console.warn('No pending user data found, user record may not be created');
+            console.warn(
+              "No pending user data found, user record may not be created",
+            );
           }
         } catch (dbError) {
           // Log the error but don't fail the verification process
-          console.error('Failed to save user to DynamoDB:', dbError);
+          console.error("Failed to save user to DynamoDB:", dbError);
           // The user is still verified and logged in, just not in the database yet
         }
-        
+
         // Clear the temporary data
-        sessionStorage.removeItem('tempPassword');
-        toast.success('Email verified!', 'Welcome to Miliare');
-        navigate('/dashboard');
+        sessionStorage.removeItem("tempPassword");
+        toast.success("Email verified!", "Welcome to Miliare");
+        navigate("/dashboard");
       } else {
         // Fallback to login page if no temp password found
-        toast.success('Verification successful', 'You can now sign in');
-        navigate('/login');
+        toast.success("Verification successful", "You can now sign in");
+        navigate("/login");
       }
     } catch (error) {
-      console.error('Verification error:', error);
-      toast.error('Verification failed', 'Invalid code or email');
+      console.error("Verification error:", error);
+      toast.error("Verification failed", "Invalid code or email");
     } finally {
       setIsSubmitting(false);
     }
@@ -114,34 +124,46 @@ const VerifyEmailPage: React.FC = () => {
 
   const resend = async () => {
     try {
-      const email = watch('email');
+      const email = watch("email");
       await resendSignUpCode({ username: email });
-      toast.success('Code resent', 'Check your email for a new code');
+      toast.success("Code resent", "Check your email for a new code");
     } catch (error) {
-      console.error('Resend code error:', error);
-      toast.error('Unable to resend code');
+      console.error("Resend code error:", error);
+      toast.error("Unable to resend code");
     }
   };
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h1 className="text-center text-3xl font-bold text-gray-900">Verify Your Email</h1>
+        <h1 className="text-center text-3xl font-bold text-gray-900">
+          Verify Your Email
+        </h1>
         <p className="mt-2 text-center text-gray-600">
-          {initialEmail ? 'Enter the code sent to your email address' : 'Enter your email and the verification code'}
+          {initialEmail
+            ? "Enter the code sent to your email address"
+            : "Enter your email and the verification code"}
         </p>
       </div>
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-            <Input label="Email" {...register('email')} error={errors.email?.message} />
-            <Input label="Verification Code" {...register('code')} error={errors.code?.message} />
+            <Input
+              label="Email"
+              {...register("email")}
+              error={errors.email?.message}
+            />
+            <Input
+              label="Verification Code"
+              {...register("code")}
+              error={errors.code?.message}
+            />
             <div className="flex justify-between items-center">
               <Button type="button" variant="outline" onClick={resend}>
                 Resend Code
               </Button>
               <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? 'Verifying...' : 'Verify'}
+                {isSubmitting ? "Verifying..." : "Verify"}
               </Button>
             </div>
           </form>


### PR DESCRIPTION
## Summary
- allow authenticated IAM access with identityPool in Amplify data schema
- remove unused auth import in VerifyEmailPage
- use API key auth for referral webhook lambda

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684bbab695188332bb643f7021dfcc32