### PR TITLE
Update Organization page to Teams view

### DIFF
--- a/apps/frontend-app/src/__tests__/TeamAccess.test.tsx
+++ b/apps/frontend-app/src/__tests__/TeamAccess.test.tsx
@@ -37,7 +37,7 @@ describe('Team access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /team/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^Team$/i })).toBeInTheDocument();
   });
 
   it('shows Team link for users in admin group', () => {
@@ -58,7 +58,7 @@ describe('Team access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /team/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^Team$/i })).toBeInTheDocument();
   });
 
   it('hides Team link for users without teamLead group', () => {
@@ -79,7 +79,7 @@ describe('Team access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByRole('link', { name: /team/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /^Team$/i })).not.toBeInTheDocument();
   });
 
   it('restricts /dashboard/team route when user lacks required groups', () => {

--- a/apps/frontend-app/src/components/TeamMembersCard.tsx
+++ b/apps/frontend-app/src/components/TeamMembersCard.tsx
@@ -26,7 +26,7 @@ const TeamMembersCard: React.FC<TeamMembersCardProps> = ({
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Members</h2>
+        <h2 className="text-lg font-semibold text-gray-900">Team Leads</h2>
         {onViewAll && (
           <Button variant="outline" size="sm" onClick={onViewAll}>
             View All

--- a/apps/frontend-app/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend-app/src/layouts/DashboardLayout.tsx
@@ -13,7 +13,7 @@ import {
   Bell,
   ChevronDown,
   Settings,
-  Building2,
+  Group,
 } from 'lucide-react';
 import { Button } from '../components/ui/Button';
 import { toast } from '../components/ui/Toaster';
@@ -53,7 +53,7 @@ const DashboardLayout = () => {
   }
 
   if (user?.groups?.includes('orgLead') || user?.groups?.includes('admin')) {
-    navLinks.push({ to: '/dashboard/organization', icon: <Building2 className="h-5 w-5" />, label: 'Organization' });
+    navLinks.push({ to: '/dashboard/organization', icon: <Group className="h-5 w-5" />, label: 'Teams' });
   }
 
   if (user?.groups?.includes('companyAdmin') || user?.groups?.includes('admin')) {

--- a/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/OrganizationPage.tsx
@@ -94,7 +94,7 @@ const OrganizationPage = () => {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Organization Dashboard</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Your Teams Dashboard</h1>
         <p className="mt-1 text-sm text-gray-500">Manage companies and referral settings.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- rename Organization nav link to **Teams** and use Group icon
- update Organization dashboard title to **Your Teams Dashboard**
- rename Members card heading to **Team Leads**
- adjust tests for new nav link text

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_b_684bc0b282588332ba6b0b90d3ab9f60