### PR TITLE
Implement company admin member & payment management

### DIFF
--- a/apps/frontend-app/src/components/CompanyMembersCard.tsx
+++ b/apps/frontend-app/src/components/CompanyMembersCard.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { Button } from './ui/Button'
+
+export type CompanyMember = {
+  id: string | number
+  name: string
+  email?: string
+  active?: boolean
+}
+
+interface CompanyMembersCardProps {
+  members: CompanyMember[]
+  onToggleStatus?: (id: string | number) => void
+}
+
+const CompanyMembersCard: React.FC<CompanyMembersCardProps> = ({ members, onToggleStatus }) => {
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Company Members</h2>
+
+      <div className="block md:hidden space-y-4">
+        {members.map((member) => (
+          <div key={member.id} className="p-4 border border-gray-200 rounded-lg">
+            <h3 className="font-medium text-gray-900 mb-1">{member.name}</h3>
+            {member.email && <p className="text-sm text-gray-600 mb-2">{member.email}</p>}
+            {onToggleStatus && (
+              <div className="mt-2">
+                <Button variant="outline" size="sm" onClick={() => onToggleStatus(member.id)}>
+                  {member.active ? 'Deactivate' : 'Activate'}
+                </Button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              {onToggleStatus && (
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Action
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {members.map((member) => (
+              <tr key={member.id} className="hover:bg-gray-50">
+                <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{member.name}</td>
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">{member.email}</td>
+                {onToggleStatus && (
+                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <Button variant="outline" size="sm" onClick={() => onToggleStatus(member.id)}>
+                      {member.active ? 'Deactivate' : 'Activate'}
+                    </Button>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default CompanyMembersCard

--- a/apps/frontend-app/src/components/PendingPaymentsCard.tsx
+++ b/apps/frontend-app/src/components/PendingPaymentsCard.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { CreditCard } from 'lucide-react'
+import { Button } from './ui/Button'
+
+export type PendingPayment = {
+  id: string | number
+  date: string
+  amount: number
+  status: string
+  company: string
+}
+
+interface PendingPaymentsCardProps {
+  payments: PendingPayment[]
+  onViewHistory?: () => void
+  onStatusChange?: (id: string | number, status: 'PROCESSED' | 'FAILED') => void
+}
+
+const PendingPaymentsCard: React.FC<PendingPaymentsCardProps> = ({ payments, onViewHistory, onStatusChange }) => {
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Pending Payments</h2>
+        {onViewHistory && (
+          <Button variant="outline" size="sm" onClick={onViewHistory}>
+            Payment History
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        {payments.map((payment) => (
+          <div
+            key={payment.id}
+            className="flex items-center p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+          >
+            <div className="flex-shrink-0">
+              <CreditCard className="h-8 w-8 text-gray-400" />
+            </div>
+            <div className="ml-4 flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">{payment.company}</p>
+              <p className="text-xs text-gray-500">{new Date(payment.date).toLocaleDateString()}</p>
+            </div>
+            <div className="ml-4 text-right">
+              <p className="text-sm font-semibold text-gray-900">${payment.amount.toLocaleString()}</p>
+              <p className="text-xs font-medium text-green-600">{payment.status}</p>
+            </div>
+            {onStatusChange && (
+              <div className="ml-4 space-x-2">
+                <Button variant="outline" size="sm" onClick={() => onStatusChange(payment.id, 'PROCESSED')}>
+                  Processed
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => onStatusChange(payment.id, 'FAILED')}>
+                  Failed
+                </Button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {payments.length === 0 && (
+        <div className="text-center py-8">
+          <CreditCard className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+          <p className="text-gray-500 text-sm">No recent payments</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PendingPaymentsCard

--- a/apps/frontend-app/src/utils/manageUsers.ts
+++ b/apps/frontend-app/src/utils/manageUsers.ts
@@ -1,0 +1,74 @@
+import { CognitoIdentityProviderClient, ListUsersCommand, AdminUpdateUserAttributesCommand } from '@aws-sdk/client-cognito-identity-provider';
+import { fetchAuthSession } from 'aws-amplify/auth';
+
+export interface CompanyUser {
+  id: string;
+  name: string;
+  email: string;
+  activated: boolean;
+}
+
+function getClient() {
+  const region = import.meta.env.VITE_AWS_REGION;
+  const userPoolId = import.meta.env.VITE_COGNITO_USER_POOL_ID;
+  if (!region || !userPoolId) {
+    throw new Error('Missing Cognito configuration');
+  }
+  return { region, userPoolId };
+}
+
+export async function listCompanyUsers(companyId: string): Promise<CompanyUser[]> {
+  const { region, userPoolId } = getClient();
+  const { credentials } = await fetchAuthSession();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    credentials: {
+      accessKeyId: credentials!.accessKeyId,
+      secretAccessKey: credentials!.secretAccessKey,
+      sessionToken: credentials!.sessionToken,
+    },
+  });
+
+  const resp = await client.send(
+    new ListUsersCommand({
+      UserPoolId: userPoolId,
+      Filter: `custom:companyId = "${companyId}"`,
+    })
+  );
+
+  return (
+    resp.Users || []
+  ).map((u) => {
+    const attrs: Record<string, string> = {};
+    (u.Attributes || []).forEach((a) => {
+      if (a.Name && a.Value) attrs[a.Name] = a.Value;
+    });
+    return {
+      id: u.Username || '',
+      name: `${attrs.given_name || ''} ${attrs.family_name || ''}`.trim() || attrs.email || u.Username || '',
+      email: attrs.email || '',
+      activated: attrs['custom:activated'] === 'true',
+    } as CompanyUser;
+  });
+}
+
+export async function setUserActivated(username: string, activated: boolean) {
+  const { region, userPoolId } = getClient();
+  const { credentials } = await fetchAuthSession();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    credentials: {
+      accessKeyId: credentials!.accessKeyId,
+      secretAccessKey: credentials!.secretAccessKey,
+      sessionToken: credentials!.sessionToken,
+    },
+  });
+
+  await client.send(
+    new AdminUpdateUserAttributesCommand({
+      UserPoolId: userPoolId,
+      Username: username,
+      UserAttributes: [{ Name: 'custom:activated', Value: activated ? 'true' : 'false' }],
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- list users of the current company using Cognito admin APIs
- add helpers to activate/deactivate users
- add CompanyMembersCard and PendingPaymentsCard to manage company data without altering existing cards
- load real members and pending payments on Company Admin page

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684bc4c950e88332a71538b877a3cd4b