### PR TITLE
Fix company meta mapping on learn page

### DIFF
--- a/apps/frontend-app/src/data/companyMeta.tsx
+++ b/apps/frontend-app/src/data/companyMeta.tsx
@@ -87,3 +87,16 @@ export const companyMeta: Record<string, CompanyMeta> = {
     commissionInfo: { rate: 'TBD', average: 'TBD' },
   },
 };
+
+export const companyNameMap: Record<string, string> = {
+  'Sunny Hill Financial': 'sunny-hill',
+  'Prime Corporate Services': 'prime',
+  'ANCO Insurance': 'anco',
+  'Weightless Financial': 'weightless',
+  'Summit Retirement Plans': 'summit',
+  'Wellness for the Workforce': 'wellness',
+  'Impact Health Sharing': 'impact',
+};
+
+export const getCompanyMetaKey = (companyName: string): string =>
+  companyNameMap[companyName] || '';

--- a/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/CompanyDetailPage.tsx
@@ -16,7 +16,7 @@ import { toast } from "../../components/ui/Toaster";
 import StatsOverview, { StatItem } from "../../components/StatsOverview";
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "../../amplify/data/resource";
-import { companyMeta } from "../../data/companyMeta";
+import { companyMeta, getCompanyMetaKey } from "../../data/companyMeta";
 
 const client = generateClient<Schema>();
 
@@ -32,6 +32,10 @@ const CompanyDetailPage = () => {
     Schema["TrainingResource"]["type"][]
   >([]);
   const [faqItems, setFaqItems] = useState<Schema["FaqItem"]["type"][]>([]);
+
+  const metaKey = getCompanyMetaKey(
+    company?.companyName || company?.name || "",
+  );
 
   useEffect(() => {
     const loadCompany = async () => {
@@ -156,7 +160,7 @@ const CompanyDetailPage = () => {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">{company?.name}</h1>
           <p className="text-sm text-gray-500">
-            {(companyMeta[companyId || ""]?.tags || []).join(" • ")}
+            {(companyMeta[metaKey]?.tags || []).join(" • ")}
           </p>
         </div>
       </div>
@@ -170,13 +174,12 @@ const CompanyDetailPage = () => {
             <div
               className="w-24 h-24 rounded-full flex items-center justify-center"
               style={{
-                backgroundColor:
-                  companyMeta[companyId || ""]?.bgColor || "#f3f4f6",
+                backgroundColor: companyMeta[metaKey]?.bgColor || "#f3f4f6",
               }}
             >
-              {companyMeta[companyId || ""]?.icon &&
+              {companyMeta[metaKey]?.icon &&
                 React.cloneElement(
-                  companyMeta[companyId || ""].icon as React.ReactElement,
+                  companyMeta[metaKey].icon as React.ReactElement,
                   { size: 48 },
                 )}
             </div>
@@ -189,7 +192,7 @@ const CompanyDetailPage = () => {
             <p className="mt-4 text-gray-600">{company?.description}</p>
 
             <div className="mt-6 flex flex-wrap gap-2">
-              {(companyMeta[companyId || ""]?.tags || []).map((tag, index) => (
+              {(companyMeta[metaKey]?.tags || []).map((tag, index) => (
                 <span
                   key={index}
                   className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800"
@@ -216,7 +219,7 @@ const CompanyDetailPage = () => {
               </a>
 
               <a
-                href={companyMeta[companyId || ""]?.referralUrl}
+                href={companyMeta[metaKey]?.referralUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block"
@@ -244,7 +247,7 @@ const CompanyDetailPage = () => {
               <h3 className="text-lg font-medium">Commission Rate</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {companyMeta[companyId || ""]?.commissionInfo?.rate || "15-20%"}
+              {companyMeta[metaKey]?.commissionInfo?.rate || "15-20%"}
             </p>
             <p className="mt-2 text-sm text-gray-500">Of the service value</p>
           </div>
@@ -255,8 +258,7 @@ const CompanyDetailPage = () => {
               <h3 className="text-lg font-medium">Average Payout</h3>
             </div>
             <p className="text-3xl font-bold text-gray-900">
-              {companyMeta[companyId || ""]?.commissionInfo?.average ||
-                "$500-$1,200"}
+              {companyMeta[metaKey]?.commissionInfo?.average || "$500-$1,200"}
             </p>
             <p className="mt-2 text-sm text-gray-500">
               Per successful referral
@@ -387,7 +389,7 @@ const CompanyDetailPage = () => {
           </div>
           <div className="mt-6 md:mt-0">
             <a
-              href={companyMeta[companyId || ""]?.referralUrl}
+              href={companyMeta[metaKey]?.referralUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block"

--- a/apps/frontend-app/src/pages/dashboard/LearnPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/LearnPage.tsx
@@ -11,7 +11,11 @@ import {
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { Button } from '../../components/ui/Button';
-import { companyMeta, type CompanyMeta } from '../../data/companyMeta';
+import {
+  companyMeta,
+  type CompanyMeta,
+  getCompanyMetaKey,
+} from '../../data/companyMeta';
 
 const client = generateClient<Schema>();
 
@@ -70,7 +74,11 @@ const LearnPage = () => {
       {/* Company grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {companies.map((company) => {
-          const meta = companyMeta[company.id] || defaultMeta;
+          const meta =
+            companyMeta[
+              getCompanyMetaKey(company.companyName || company.name || '')
+            ] ||
+            defaultMeta;
           return (
             <div key={company.id} className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
             <div className="p-6">

--- a/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/ReferPage.tsx
@@ -9,7 +9,7 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../../amplify/data/resource';
-import { companyMeta } from '../../data/companyMeta';
+import { companyMeta, getCompanyMetaKey } from '../../data/companyMeta';
 import { toast } from '../../components/ui/Toaster';
 import ReferralFormModal from '../../components/ReferralFormModal';
 
@@ -34,19 +34,6 @@ const ReferPage = () => {
     fetchCompanies();
   }, []);
 
-  // Map company names to metadata keys
-  const getCompanyMetaKey = (companyName: string) => {
-    const nameMap: Record<string, string> = {
-      'Sunny Hill Financial': 'sunny-hill',
-      'Prime Corporate Services': 'prime',
-      'ANCO Insurance': 'anco',
-      'Weightless Financial': 'weightless',
-      'Summit Retirement Plans': 'summit',
-      'Wellness for the Workforce': 'wellness',
-      'Impact Health Sharing': 'impact',
-    };
-    return nameMap[companyName] || '';
-  };
 
   const categories = Array.from(
     new Set(


### PR DESCRIPTION
## Summary
- expose `getCompanyMetaKey` helper in company meta data
- use `getCompanyMetaKey` on Refer, Learn, and Company Detail pages

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684bca858ba08332bb84ce58012dc41f