### PR TITLE
Add referral status update options

### DIFF
--- a/apps/frontend-app/src/components/ReferralFormModal.tsx
+++ b/apps/frontend-app/src/components/ReferralFormModal.tsx
@@ -13,7 +13,11 @@ import { toast } from './ui/Toaster';
 const formSchema = z.object({
   name: z.string().trim().min(2, 'Name must be at least 2 characters').max(100, 'Name too long'),
   email: z.string().trim().email('Please enter a valid email address').toLowerCase(),
-  phone: z.string().trim().min(10, 'Phone number must be at least 10 digits').regex(/^[\d\s\-\(\)\+\.]+$/, 'Please enter a valid phone number'),
+  phone: z
+    .string()
+    .trim()
+    .min(10, 'Phone number must be at least 10 digits')
+    .regex(/^[\d\s-()+.]+$/, 'Please enter a valid phone number'),
   referralType: z.string().trim().min(3, 'Please describe the type of referral (minimum 3 characters)').max(200, 'Description too long'),
   value: z.string().trim().min(1, 'Approximate value is required')
     .refine((val: string) => {

--- a/apps/frontend-app/src/components/ui/Select.tsx
+++ b/apps/frontend-app/src/components/ui/Select.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import { cn } from '../../utils/cn';
 
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
 export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   error?: string;
-  options: Array<{ value: string; label: string }>;
+  options: SelectOption[];
 }
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
@@ -29,7 +35,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         >
           <option value="" disabled>Select an option</option>
           {options.map((option) => (
-            <option key={option.value} value={option.value}>
+            <option key={option.value} value={option.value} disabled={option.disabled}>
               {option.label}
             </option>
           ))}

--- a/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/BusinessPage.tsx
@@ -171,8 +171,12 @@ const BusinessPage = () => {
     setActiveReferral(referral);
   };
 
-  const handleStatusUpdated = (id: string) => {
-    setPendingReferrals((prev) => prev.filter((r) => r.id !== id));
+  const handleStatusUpdated = (id: string, newStatus: string) => {
+    setPendingReferrals((prev) =>
+      prev
+        .map((r) => (r.id === id ? { ...r, status: newStatus } : r))
+        .filter((r) => !(r.id === id && newStatus === 'PAID'))
+    );
   };
 
   const handleViewPaymentHistory = () => {


### PR DESCRIPTION
## Summary
- show referral creation date and allow status update in modal
- handle all statuses in business page and update referral form phone regex
- support disabled options in Select component

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684bd879d90c8332a795014aaead6b9b