### PR TITLE
Fix site admin key gen access

### DIFF
--- a/apps/frontend-app/src/App.tsx
+++ b/apps/frontend-app/src/App.tsx
@@ -106,7 +106,7 @@ function App() {
           <Route
             path="site-admin"
             element={
-              <ProtectedRoute requiredGroup="admin">
+              <ProtectedRoute requiredGroup="siteAdmin">
                 <SiteAdminPage />
               </ProtectedRoute>
             }


### PR DESCRIPTION
## Summary
- only allow siteAdmin members to reach the site-admin page

## Testing
- `npm run frontend:lint`
- `npm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684ca5f13e008332b038bde947a8c545