### PR TITLE
Fix API key generation permissions

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -33,7 +33,7 @@ export const schema = a.schema({
     })
     .authorization((allow) => [
       allow.guest().to(["read"]),
-      allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.group("siteAdmin").to(["create", "read", "update", "delete"]),
       allow.group("companyAdmin").to(["read", "update"]),
       allow.authenticated("identityPool").to(["read"]),
       // Allow API key for seed scripts


### PR DESCRIPTION
## Summary
- allow siteAdmin group CRUD access to Company data

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684ca8757d488332923afe900c320ad6