### PR TITLE
Fix data permissions for normal users

### DIFF
--- a/apps/frontend-app/amplify/data/resource.ts
+++ b/apps/frontend-app/amplify/data/resource.ts
@@ -35,6 +35,7 @@ export const schema = a.schema({
       allow.guest().to(["read"]),
       allow.group("admin").to(["create", "read", "update", "delete"]),
       allow.group("companyAdmin").to(["read", "update"]),
+      allow.authenticated("userPool").to(["read"]),
       allow.authenticated("identityPool").to(["read"]),
       // Allow API key for seed scripts
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
@@ -132,6 +133,7 @@ export const schema = a.schema({
     })
     .authorization((allow) => [
       allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.authenticated("userPool").to(["read"]),
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),
 
@@ -148,6 +150,7 @@ export const schema = a.schema({
     })
     .authorization((allow) => [
       allow.group("admin").to(["create", "read", "update", "delete"]),
+      allow.authenticated("userPool").to(["read"]),
       allow.publicApiKey().to(["create", "read", "update", "delete"]),
     ]),
 });


### PR DESCRIPTION
## Summary
- allow signed-in users to read Company records
- allow signed-in users to read TrainingResource and FaqItem records

## Testing
- `pnpm run frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684cff93ced88332ae8418c120e1551f