### PR TITLE
Add unit tests and improve Input component

### DIFF
--- a/apps/frontend-app/src/__tests__/ForgotPasswordPage.test.tsx
+++ b/apps/frontend-app/src/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import ForgotPasswordPage from "../pages/ForgotPasswordPage";
+import * as Auth from "aws-amplify/auth";
+
+vi.mock("aws-amplify/auth", () => ({
+  resetPassword: vi.fn(),
+  confirmResetPassword: vi.fn(),
+}));
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <ForgotPasswordPage />
+    </BrowserRouter>,
+  );
+}
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows validation error when email is empty", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /send code/i }));
+    expect(
+      await screen.findByText(/please enter a valid email address/i),
+    ).toBeInTheDocument();
+  });
+
+  it("submits reset code and new password", async () => {
+    const resetMock = Auth.resetPassword as unknown as jest.Mock;
+    const confirmMock = Auth.confirmResetPassword as unknown as jest.Mock;
+    resetMock.mockResolvedValue(undefined);
+    confirmMock.mockResolvedValue(undefined);
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send code/i }));
+
+    await waitFor(() =>
+      expect(resetMock).toHaveBeenCalledWith({ username: "user@example.com" }),
+    );
+    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/verification code/i), {
+      target: { value: "123456" },
+    });
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: "Password1!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() =>
+      expect(confirmMock).toHaveBeenCalledWith({
+        username: "user@example.com",
+        confirmationCode: "123456",
+        newPassword: "Password1!",
+      }),
+    );
+  });
+});

--- a/apps/frontend-app/src/__tests__/VerifyEmailPage.test.tsx
+++ b/apps/frontend-app/src/__tests__/VerifyEmailPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import VerifyEmailPage from "../pages/VerifyEmailPage";
+import * as Auth from "aws-amplify/auth";
+
+vi.mock("aws-amplify/auth", () => ({
+  confirmSignUp: vi.fn(),
+  resendSignUpCode: vi.fn(),
+}));
+
+const loginMock = vi.fn();
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({ login: loginMock }),
+}));
+
+vi.mock("aws-amplify/data", () => ({
+  generateClient: vi.fn(() => ({ models: { User: { create: vi.fn() } } })),
+}));
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual: any = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function renderPage(state?: any) {
+  const initialEntries = [{ pathname: "/verify", state }];
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <VerifyEmailPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("VerifyEmailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefills email from navigation state", () => {
+    renderPage({ email: "user@example.com" });
+    expect(screen.getByLabelText(/email/i)).toHaveValue("user@example.com");
+  });
+
+  it("shows validation errors when form is empty", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+    expect(
+      await screen.findByText(/please enter a valid email/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/verification code is required/i),
+    ).toBeInTheDocument();
+  });
+
+  it("submits verification code and logs in", async () => {
+    const confirmMock = Auth.confirmSignUp as unknown as jest.Mock;
+    confirmMock.mockResolvedValue(undefined);
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/verification code/i), {
+      target: { value: "111111" },
+    });
+    sessionStorage.setItem("tempPassword", "Temp1234!");
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    await waitFor(() =>
+      expect(confirmMock).toHaveBeenCalledWith({
+        username: "user@example.com",
+        confirmationCode: "111111",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(loginMock).toHaveBeenCalledWith("user@example.com", "Temp1234!"),
+    );
+  });
+});

--- a/apps/frontend-app/src/__tests__/cn.test.ts
+++ b/apps/frontend-app/src/__tests__/cn.test.ts
@@ -1,0 +1,11 @@
+import { cn } from "../utils/cn";
+
+describe("cn utility", () => {
+  it("concatenates class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("merges tailwind classes with precedence", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+  });
+});

--- a/apps/frontend-app/src/components/ui/Input.tsx
+++ b/apps/frontend-app/src/components/ui/Input.tsx
@@ -7,15 +7,18 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, label, error, ...props }, ref) => {
+  ({ className, type, label, error, id, ...props }, ref) => {
+    const inputId = React.useId();
+    const finalId = id ?? inputId;
     return (
       <div className="space-y-2">
         {label && (
-          <label className="block text-sm font-medium text-gray-700">
+          <label htmlFor={finalId} className="block text-sm font-medium text-gray-700">
             {label}
           </label>
         )}
         <input
+          id={finalId}
           type={type}
           className={cn(
             'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background',


### PR DESCRIPTION
## Summary
- add ForgotPasswordPage tests covering validation and submit flow
- add VerifyEmailPage tests including login call
- test Tailwind class merge utility
- refactor Input component to generate accessible id for labels

## Testing
- `pnpm frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_684d985a9b708332aa938a7d3e0245d4