### PR TITLE
Update team and division member filtering

### DIFF
--- a/apps/frontend-app/src/__tests__/VerifyEmailPage.test.tsx
+++ b/apps/frontend-app/src/__tests__/VerifyEmailPage.test.tsx
@@ -19,11 +19,13 @@ vi.mock("aws-amplify/data", () => ({
 
 const navigate = vi.fn();
 vi.mock("react-router-dom", async () => {
-  const actual: any = await vi.importActual("react-router-dom");
+  const actual = (await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  )) as typeof import("react-router-dom");
   return { ...actual, useNavigate: () => navigate };
 });
 
-function renderPage(state?: any) {
+function renderPage(state?: { email?: string }) {
   const initialEntries = [{ pathname: "/verify", state }];
   return render(
     <MemoryRouter initialEntries={initialEntries}>

--- a/apps/frontend-app/src/pages/dashboard/DivisionPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/DivisionPage.tsx
@@ -26,7 +26,10 @@ const DivisionPage = () => {
 
       try {
         const { data: users } = await client.models.User.list({
-          filter: { divisionLeadId: { eq: user.id } },
+          filter: {
+            divisionLeadId: { eq: user.id },
+            teamLead: { eq: true },
+          },
         });
 
         const memberResults: TeamMember[] = [];

--- a/apps/frontend-app/src/pages/dashboard/SiteAdminPage.tsx
+++ b/apps/frontend-app/src/pages/dashboard/SiteAdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { RefreshCw, Copy, Check } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { generateClient } from 'aws-amplify/data';
@@ -63,7 +63,9 @@ const SiteAdminPage = () => {
     };
 
     loadCompanyData();
-  }, [user?.companyId]); // Remove client from dependencies to prevent infinite loop
+  // Remove client from dependencies to prevent infinite loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.companyId]);
 
   const handleRegenerate = async () => {
     if (!company) {


### PR DESCRIPTION
## Summary
- filter division dashboard members to only show team leads
- fix React Router mock typing
- remove unused import in site admin page
- silence exhaust-deps warning

## Testing
- `pnpm frontend:lint`
- `pnpm frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684d9f1297688332a49157db23026c18